### PR TITLE
Implement extended_properties

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -7505,7 +7505,7 @@ namespace ews
         internet_message_header() = delete;
 #else
     private:
-        internet_message_header() {}
+        internet_message_header();
 
     public:
 #endif
@@ -7543,382 +7543,164 @@ namespace ews
     static_assert(std::is_move_assignable<internet_message_header>::value, "");
 #endif
 
-    //! The ExtendedFieldURI element identifies an extended MAPI property.
+    namespace internal
+    {
+        // Wraps a string so that it become its own type
+        template <int tag> class str_wrapper final
+        {
+        public:
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+            str_wrapper() = default;
+#else
+            str_wrapper() : value_() {}
+#endif
+
+            explicit str_wrapper(std::string str) : value_(std::move(str)) {}
+
+            const std::string& str() const noexcept { return value_; }
+
+        private:
+            std::string value_;
+        };
+
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+        static_assert(std::is_default_constructible<str_wrapper<0>>::value, "");
+        static_assert(std::is_copy_constructible<str_wrapper<0>>::value, "");
+        static_assert(std::is_copy_assignable<str_wrapper<0>>::value, "");
+        static_assert(std::is_move_constructible<str_wrapper<0>>::value, "");
+        static_assert(std::is_move_assignable<str_wrapper<0>>::value, "");
+#endif
+
+        enum type_tags
+        {
+            distinguished_property_set_id,
+            property_set_id,
+            property_tag,
+            property_name,
+            property_id,
+            property_type
+        };
+    }
+
+    //! The ExtendedFieldURI element identifies an extended MAPI property
     class extended_field_uri final
     {
     public:
-        //! \brief Represents the <tt>\<PropertySetId\></tt> of an
-        //! <tt>\<ExtendedFieldUri\></tt>.
-        //!
-        //! Defines the well-known property set IDs for extended MAPI
-        //! properties. If this attribute is used, the PropertySetId and
-        //! PropertyTag attributes cannot be used. This attribute must be
-        //! used with either the PropertyId or PropertyName attribute, and
-        //! the PropertyType attribute. The DistinguishedPropertySetId
-        //! Attribute table later in this topic lists the possible values
-        //! for this attribute. This attribute is optional.
-        class distinguished_property_set_id final
-        {
-        public:
-//! Default constructor
+#ifndef EWS_DOXYGEN_SHOULD_SKIP_THIS
+        using distinguished_property_set_id =
+            internal::str_wrapper<internal::distinguished_property_set_id>;
+        using property_set_id =
+            internal::str_wrapper<internal::property_set_id>;
+        using property_tag = internal::str_wrapper<internal::property_tag>;
+        using property_name = internal::str_wrapper<internal::property_name>;
+        using property_id = internal::str_wrapper<internal::property_id>;
+        using property_type = internal::str_wrapper<internal::property_type>;
+#endif
+
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
-            distinguished_property_set_id() = default;
+        extended_field_uri() = delete;
 #else
-            distinguished_property_set_id() {}
-#endif
-            //! Constructor to create an DistinguishedPropertySetId property
-            explicit distinguished_property_set_id(std::string str)
-                : str_(std::move(str))
-            {
-            }
+    private:
+        extended_field_uri();
 
-            //! Returns this property as a string.
-            const std::string& str() const EWS_NOEXCEPT { return str_; }
-
-        private:
-            std::string str_;
-        };
-
-#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
-        static_assert(
-            std::is_default_constructible<distinguished_property_set_id>::value,
-            "");
-        static_assert(
-            std::is_copy_constructible<distinguished_property_set_id>::value,
-            "");
-        static_assert(
-            std::is_copy_assignable<distinguished_property_set_id>::value, "");
-        static_assert(
-            std::is_move_constructible<distinguished_property_set_id>::value,
-            "");
-        static_assert(
-            std::is_move_assignable<distinguished_property_set_id>::value, "");
+    public:
 #endif
 
-        //! \brief Represents the <tt>\<PropertySetId\></tt> of an
-        //! <tt>\<ExtendedFieldUri\></tt>.
-        //!
-        //! Identifies a MAPI extended property set or namespace by its
-        //! identifying GUID. If this attribute is used, the
-        //! DistinguishedPropertySetId and PropertyTag attribute cannot be used.
-        //! This attribute must be used with either the PropertyId or
-        //! PropertyName attribute, and the PropertyType attribute.
-        //! This attribute is optional.
-        class property_set_id final
-        {
-        public:
-//! Default constructor
-#ifdef EWS_HAS_DEFAULT_AND_DELETE
-            property_set_id() = default;
-#else
-            property_set_id() {}
-#endif
-            //! Constructor to create a PropertySetId property
-            explicit property_set_id(std::string str) : str_(std::move(str)) {}
-
-            //! Returns this property as a string.
-            const std::string& str() const EWS_NOEXCEPT { return str_; }
-
-        private:
-            std::string str_;
-        };
-
-#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
-        static_assert(std::is_default_constructible<property_set_id>::value,
-                      "");
-        static_assert(std::is_copy_constructible<property_set_id>::value, "");
-        static_assert(std::is_copy_assignable<property_set_id>::value, "");
-        static_assert(std::is_move_constructible<property_set_id>::value, "");
-        static_assert(std::is_move_assignable<property_set_id>::value, "");
-#endif
-
-        //! \brief Represents the <tt>\<PropertyTag\></tt> of an
-        //! <tt>\<ExtendedFieldUri\></tt>.
-        //!
-        //! Identifies the property tag without the type part of the tag.
-        //! The PropertyTag can be represented as either a hexadecimal or a
-        //! short integer. The range between 0x8000 and 0xFFFE represents the
-        //! custom range of properties. When a mailbox database encounters a
-        //! custom property for the first time, it assigns that custom property
-        //! a property tag within the custom property range of 0x8000-0xFFFE.
-        //! A given custom property tag will most likely differ across
-        //! databases.
-        //! Therefore, a custom property request by property tag can return
-        //! different properties on different databases. The use of the
-        //! PropertyTag attribute is prohibited for custom properties.
-        //! Instead, use the PropertySetId attribute and the PropertyName
-        //! or PropertyId attribute.
-        //! If the PropertyTag attribute is used, the
-        //! DistinguishedPropertySetId,
-        //! PropertySetId, PropertyName, and PropertyId attributes cannot be
-        //! used.
-        //! This attribute is optional.
-        class property_tag final
-        {
-        public:
-//! Default constructor
-#ifdef EWS_HAS_DEFAULT_AND_DELETE
-            property_tag() = default;
-#else
-            property_tag() {}
-#endif
-            //! Constructor to create a PropertyTag property
-            explicit property_tag(std::string str) : str_(std::move(str)) {}
-
-            //! Returns this property as a string.
-            const std::string& str() const EWS_NOEXCEPT { return str_; }
-
-        private:
-            std::string str_;
-        };
-
-#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
-        static_assert(std::is_default_constructible<property_tag>::value, "");
-        static_assert(std::is_copy_constructible<property_tag>::value, "");
-        static_assert(std::is_copy_assignable<property_tag>::value, "");
-        static_assert(std::is_move_constructible<property_tag>::value, "");
-        static_assert(std::is_move_assignable<property_tag>::value, "");
-#endif
-
-        //! \brief Represents the <tt>\<PropertyName\></tt> of an
-        //! <tt>\<ExtendedFieldUri\></tt>.
-        //!
-        //! Identifies an extended property by its name.
-        //! This property must be coupled with either DistinguishedPropertySetId
-        //! or PropertySetId.
-        //! If this attribute is used, the PropertyId and PropertyTag attributes
-        //! cannot be used. This attribute is optional.
-        class property_name final
-        {
-        public:
-//! Default constructor
-#ifdef EWS_HAS_DEFAULT_AND_DELETE
-            property_name() = default;
-#else
-            property_name() {}
-#endif
-            //! Constructor to create a PropertyTag property
-            explicit property_name(std::string str) : str_(std::move(str)) {}
-
-            //! Returns this property as a string.
-            const std::string& str() const EWS_NOEXCEPT { return str_; }
-
-        private:
-            std::string str_;
-        };
-
-#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
-        static_assert(std::is_default_constructible<property_name>::value, "");
-        static_assert(std::is_copy_constructible<property_name>::value, "");
-        static_assert(std::is_copy_assignable<property_name>::value, "");
-        static_assert(std::is_move_constructible<property_name>::value, "");
-        static_assert(std::is_move_assignable<property_name>::value, "");
-#endif
-
-        //! \brief Represents the <tt>\<PropertyId\></tt> of an
-        //! <tt>\<ExtendedFieldUri\></tt>.
-        //!
-        //! Identifies an extended property by its dispatch ID. The dispatch ID
-        //! can be identified in either decimal or hexadecimal formats.
-        //! This property must be coupled with either DistinguishedPropertySetId
-        //! or PropertySetId. If this attribute is used, the PropertyName and
-        //! PropertyTag attributes cannot be used. This attribute is optional.
-        class property_id final
-        {
-        public:
-//! Default constructor
-#ifdef EWS_HAS_DEFAULT_AND_DELETE
-            property_id() = default;
-#else
-            property_id() {}
-#endif
-            //! Constructor to create a PropertyId property
-            explicit property_id(std::string str) : str_(std::move(str)) {}
-
-            //! Returns this property as a string.
-            const std::string& str() const EWS_NOEXCEPT { return str_; }
-
-        private:
-            std::string str_;
-        };
-
-        //! \brief Represents the <tt>\<PropertyType\></tt> of an
-        //! <tt>\<ExtendedFieldUri\></tt>.
-        //!
-        //! Represents the property type of a property tag. This corresponds
-        //! to the least significant word in a property tag. The PropertyType
-        //! Attribute table later in this topic contains the possible values
-        //! for this attribute. This attribute is required.
-        class property_type final
-        {
-        public:
-//! Default constructor
-#ifdef EWS_HAS_DEFAULT_AND_DELETE
-            property_type() = default;
-#else
-            property_type() {}
-#endif
-            //! Constructor to create a PropertyType property
-            explicit property_type(std::string str) : str_(std::move(str)) {}
-
-            //! Returns this property as a string.
-            const std::string& str() const EWS_NOEXCEPT { return str_; }
-
-            extended_field_uri
-            form_xml_element(const rapidxml::xml_node<>& elem);
-
-        private:
-            std::string str_;
-        };
-
-        //! \brief Constructor for initialization based on
-        //! distinguished_property_set_id
-        //! and property_id
-        extended_field_uri(
-            distinguished_property_set_id distinguished_property_set_id,
-            property_id property_id, property_type property_type)
-            : distinguished_property_set_id_(
-                  std::move(distinguished_property_set_id)),
-              property_id_(std::move(property_id)),
-              property_type_(std::move(property_type))
+        extended_field_uri(distinguished_property_set_id set_id, property_id id,
+                           property_type type)
+            : distinguished_set_id_(std::move(set_id)), id_(std::move(id)),
+              type_(std::move(type))
         {
         }
 
-        //! \brief Constructor for initialization based on
-        //! distinguished_property_set_id
-        //! and property_name
-        extended_field_uri(
-            distinguished_property_set_id distinguished_property_set_id,
-            std::string property_name, property_type property_type)
-            : distinguished_property_set_id_(
-                  std::move(distinguished_property_set_id)),
-              property_name_(std::move(property_name)),
-              property_type_(std::move(property_type))
+        extended_field_uri(distinguished_property_set_id set_id,
+                           property_name name, property_type type)
+            : distinguished_set_id_(std::move(set_id)), name_(std::move(name)),
+              type_(std::move(type))
         {
         }
 
-        //! \brief Constructor for initialization based on property_set_id
-        //! and poperty_id
-        extended_field_uri(property_set_id property_set_id,
-                           property_id property_id, property_type property_type)
-            : property_set_id_(std::move(property_set_id)),
-              property_id_(std::move(property_id)),
-              property_type_(std::move(property_type))
+        extended_field_uri(property_set_id set_id, property_id id,
+                           property_type type)
+            : set_id_(std::move(set_id)), id_(std::move(id)),
+              type_(std::move(type))
         {
         }
 
-        //! \brief Constructor for initialization based on property_set_id
-        //! and property_name
-        extended_field_uri(property_set_id property_set_id,
-                           std::string property_name,
-                           property_type property_type)
-            : property_set_id_(std::move(property_set_id)),
-              property_name_(std::move(property_name)),
-              property_type_(std::move(property_type))
+        extended_field_uri(property_set_id set_id, property_name name,
+                           property_type type)
+            : set_id_(std::move(set_id)), name_(std::move(name)),
+              type_(std::move(type))
         {
         }
 
-        //! \brief Constructor for initialization based on property_tag
-        extended_field_uri(property_tag property_tag,
-                           property_type property_type)
-            : property_tag_(std::move(property_tag)),
-              property_type_(std::move(property_type))
+        extended_field_uri(property_tag tag, property_type type)
+            : tag_(std::move(tag)), type_(std::move(type))
         {
         }
 
-        //! Returns the <tt>\<DistinguishedPropertySetId\></tt> as a std::string
         const std::string&
         get_distinguished_property_set_id() const EWS_NOEXCEPT
         {
-            return distinguished_property_set_id_.str();
+            return distinguished_set_id_.str();
         }
 
-        //! Returns the <tt>\<PropertySetId\></tt> as a std::string
         const std::string& get_property_set_id() const EWS_NOEXCEPT
         {
-            return property_set_id_.str();
+            return set_id_.str();
         }
 
-        //! Returns the <tt>\<PropertyTag\></tt> as a std::string
         const std::string& get_property_tag() const EWS_NOEXCEPT
         {
-            return property_tag_.str();
+            return tag_.str();
         }
 
-        //! Returns the <tt>\<PropertyName\></tt> as a std::string
         const std::string& get_property_name() const EWS_NOEXCEPT
         {
-            return property_name_.str();
+            return name_.str();
         }
 
-        //! Returns the <tt>\<PropertyId\></tt> as a std::string
         const std::string& get_property_id() const EWS_NOEXCEPT
         {
-            return property_id_.str();
+            return id_.str();
         }
 
-        //! Returns the <tt>\<PropertyType\></tt> as a std::string
         const std::string& get_property_type() const EWS_NOEXCEPT
         {
-            return property_type_.str();
+            return type_.str();
         }
 
-        //! Sets a <tt>\<DistinguishedPropertySetId\></tt>
-        void set_distinguished_property_set_id(
-            const distinguished_property_set_id& dpsi)
-        {
-            distinguished_property_set_id_ = dpsi;
-        }
-
-        //! Sets a <tt>\<PropertySetId\></tt>
-        void set_property_set_id(const property_set_id& psi)
-        {
-            property_set_id_ = psi;
-        }
-
-        //! Sets a <tt>\<PropertyTag\></tt>
-        void set_property_tag(const property_tag& ptg) { property_tag_ = ptg; }
-
-        //! Sets a <tt>\<PropertyName\></tt>
-        void set_property_name(const property_name& pn) { property_name_ = pn; }
-
-        //! Sets a <tt>\<PropertyId\></tt>
-        void set_property_id(const property_id& pi) { property_id_ = pi; }
-
-        //! Sets a <tt>\<PropertyType\></tt>
-        void set_property_type(const property_type& pt) { property_type_ = pt; }
-
-        //! Converts an extended_field_uri into a xml string.
+        //! Returns a string representation of this extended_field_uri
         std::string to_xml()
         {
             std::stringstream sstr;
 
             sstr << "<t:ExtendedFieldURI ";
 
-            if (!distinguished_property_set_id_.str().empty())
+            if (!distinguished_set_id_.str().empty())
             {
                 sstr << "DistinguishedPropertySetId=\""
-                     << distinguished_property_set_id_.str() << "\" ";
+                     << distinguished_set_id_.str() << "\" ";
             }
-            if (!property_id_.str().empty())
+            if (!id_.str().empty())
             {
-                sstr << "PropertyId=\"" << property_id_.str() << "\" ";
+                sstr << "PropertyId=\"" << id_.str() << "\" ";
             }
-            if (!property_set_id_.str().empty())
+            if (!set_id_.str().empty())
             {
-                sstr << "PropertySetId=\"" << property_set_id_.str() << "\" ";
+                sstr << "PropertySetId=\"" << set_id_.str() << "\" ";
             }
-            if (!property_tag_.str().empty())
+            if (!tag_.str().empty())
             {
-                sstr << "PropertyTag=\"" << property_tag_.str() << "\" ";
+                sstr << "PropertyTag=\"" << tag_.str() << "\" ";
             }
-            if (!property_name_.str().empty())
+            if (!name_.str().empty())
             {
-                sstr << "PropertyName=\"" << property_name_.str() << "\" ";
+                sstr << "PropertyName=\"" << name_.str() << "\" ";
             }
-            if (!property_type_.str().empty())
+            if (!type_.str().empty())
             {
-                sstr << "PropertyType=\"" << property_type_.str() << "\"/>";
+                sstr << "PropertyType=\"" << type_.str() << "\"/>";
             }
             return sstr.str();
         }
@@ -7927,66 +7709,103 @@ namespace ews
         static extended_field_uri
         from_xml_element(const rapidxml::xml_node<>& elem)
         {
-            extended_field_uri ext_field_uri;
+            using rapidxml::internal::compare;
+
+            EWS_ASSERT(compare(elem.local_name(), elem.local_name_size(),
+                               "ExtendedFieldURI",
+                               std::strlen("ExtendedFieldURI")) &&
+                       "Expected a <ExtendedFieldURI/>, got something else");
+
+            std::string distinguished_set_id;
+            std::string set_id;
+            std::string tag;
+            std::string name;
+            std::string id;
+            std::string type;
 
             for (auto attr = elem.first_attribute(); attr != nullptr;
                  attr = attr->next_attribute())
             {
-                if (std::string(attr->name(), attr->name_size()) ==
-                    "DistinguishedPropertySetId")
+                if (compare(attr->name(), attr->name_size(),
+                            "DistinguishedPropertySetId",
+                            std::strlen("DistinguishedPropertySetId")))
                 {
-                    ext_field_uri.set_distinguished_property_set_id(
-                        distinguished_property_set_id(
-                            std::string(attr->value(), attr->value_size())));
+                    distinguished_set_id =
+                        std::string(attr->value(), attr->value_size());
                 }
-                else if (std::string(attr->name(), attr->name_size()) ==
-                         "PropertySetId")
+                else if (compare(attr->name(), attr->name_size(),
+                                 "PropertySetId", std::strlen("PropertySetId")))
                 {
-                    ext_field_uri.set_property_set_id(property_set_id(
-                        std::string(attr->value(), attr->value_size())));
+                    set_id = std::string(attr->value(), attr->value_size());
                 }
-                else if (std::string(attr->name(), attr->name_size()) ==
-                         "PropertyTag")
+                else if (compare(attr->name(), attr->name_size(), "PropertyTag",
+                                 std::strlen("PropertyTag")))
                 {
-                    ext_field_uri.set_property_tag(property_tag(
-                        std::string(attr->value(), attr->value_size())));
+                    tag = std::string(attr->value(), attr->value_size());
                 }
-                else if (std::string(attr->name(), attr->name_size()) ==
-                         "PropertyName")
+                else if (compare(attr->name(), attr->name_size(),
+                                 "PropertyName", std::strlen("PropertyName")))
                 {
-                    ext_field_uri.set_property_name(property_name(
-                        std::string(attr->value(), attr->value_size())));
+                    name = std::string(attr->value(), attr->value_size());
                 }
-                else if (std::string(attr->name(), attr->name_size()) ==
-                         "PropertyId")
+                else if (compare(attr->name(), attr->name_size(), "PropertyId",
+                                 std::strlen("PropertyId")))
                 {
-                    ext_field_uri.set_property_id(property_id(
-                        std::string(attr->value(), attr->value_size())));
+                    id = std::string(attr->value(), attr->value_size());
                 }
-                else if (std::string(attr->name(), attr->name_size()) ==
-                         "PropertyType")
+                else if (compare(attr->name(), attr->name_size(),
+                                 "PropertyType", std::strlen("PropertyType")))
                 {
-                    ext_field_uri.set_property_type(property_type(
-                        std::string(attr->value(), attr->value_size())));
+                    type = std::string(attr->value(), attr->value_size());
                 }
                 else
                 {
                     throw exception(
-                        "Unexpected child element in <ExtendedFieldURI>");
+                        "Unexpected attribute in <ExtendedFieldURI>");
                 }
             }
 
-            // Validate and constructor selection
-            if (ext_field_uri.get_property_type().empty())
+            EWS_ASSERT(!type.empty() && "Type attribute missing");
+
+            if (!distinguished_set_id.empty())
             {
-                throw exception(
-                    "Invalid empty <PropertyType> in <ExtendedFieldURI>");
+                if (!id.empty())
+                {
+                    return extended_field_uri(
+                        distinguished_property_set_id(distinguished_set_id),
+                        property_id(id), property_type(type));
+                }
+                else if (!name.empty())
+                {
+                    return extended_field_uri(
+                        distinguished_property_set_id(distinguished_set_id),
+                        property_name(name), property_type(type));
+                }
             }
-            return ext_field_uri;
+            else if (!set_id.empty())
+            {
+                if (!id.empty())
+                {
+                    return extended_field_uri(property_set_id(set_id),
+                                              property_id(id),
+                                              property_type(type));
+                }
+                else if (!name.empty())
+                {
+                    return extended_field_uri(property_set_id(set_id),
+                                              property_name(name),
+                                              property_type(type));
+                }
+            }
+            else if (!tag.empty())
+            {
+                return extended_field_uri(property_tag(tag),
+                                          property_type(type));
+            }
+
+            throw exception("Unexpected combination of ");
         }
 
-        //! Converts a xml string into a extended_field_uri rapidxml
-        //! representation.
         rapidxml::xml_node<>& to_xml_element(rapidxml::xml_node<>& parent) const
         {
             auto doc = parent.document();
@@ -8007,6 +7826,7 @@ namespace ews
                     doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
+
             if (!get_property_set_id().empty())
             {
                 auto ptr_to_attr = doc->allocate_string("PropertySetId");
@@ -8016,6 +7836,7 @@ namespace ews
                     doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
+
             if (!get_property_tag().empty())
             {
                 auto ptr_to_attr = doc->allocate_string("PropertyTag");
@@ -8025,6 +7846,7 @@ namespace ews
                     doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
+
             if (!get_property_name().empty())
             {
                 auto ptr_to_attr = doc->allocate_string("PropertyName");
@@ -8034,6 +7856,7 @@ namespace ews
                     doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
+
             if (!get_property_type().empty())
             {
                 auto ptr_to_attr = doc->allocate_string("PropertyType");
@@ -8043,6 +7866,7 @@ namespace ews
                     doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
+
             if (!get_property_id().empty())
             {
                 auto ptr_to_attr = doc->allocate_string("PropertyId");
@@ -8054,23 +7878,18 @@ namespace ews
             }
 
             parent.append_node(new_node);
-
             return *new_node;
         }
 
     private:
-#ifdef EWS_HAS_DEFAULT_AND_DELETE
-        extended_field_uri() = default;
-#else
-        extended_field_uri() {}
-#endif
-        distinguished_property_set_id distinguished_property_set_id_;
-        property_set_id property_set_id_;
-        property_tag property_tag_;
-        property_name property_name_;
-        property_id property_id_;
-        property_type property_type_;
+        distinguished_property_set_id distinguished_set_id_;
+        property_set_id set_id_;
+        property_tag tag_;
+        property_name name_;
+        property_id id_;
+        property_type type_;
     };
+
 #ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
     static_assert(!std::is_default_constructible<extended_field_uri>::value,
                   "");
@@ -8094,7 +7913,7 @@ namespace ews
         extended_property() = delete;
 #else
     private:
-        extended_property() {}
+        extended_property();
 
     public:
 #endif

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8623,12 +8623,12 @@ namespace ews
                 extended_prop.get_extended_field_uri();
             field_uri.to_xml_element(*top_node);
 
-            rapidxml::xml_node<char>* cover_node = nullptr;
+            rapidxml::xml_node<>* cover_node = nullptr;
             if (extended_prop.get_values().size() > 1)
             {
-                auto ptr_to_value = doc->allocate_string("t:Value");
+                auto ptr_to_values = doc->allocate_string("t:Values");
                 cover_node =
-                    doc->allocate_node(rapidxml::node_element, ptr_to_value);
+                    doc->allocate_node(rapidxml::node_element, ptr_to_values);
                 cover_node->namespace_uri(
                     internal::uri<>::microsoft::types(),
                     internal::uri<>::microsoft::types_size);

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8586,6 +8586,7 @@ namespace ews
             return vep;
         }
 
+        //! Sets an extended property of an item
         void set_extended_property(const extended_property& extended_prop)
         {
             auto doc = xml().document();

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -7540,6 +7540,574 @@ namespace ews
     static_assert(std::is_move_assignable<internet_message_header>::value, "");
 #endif
 
+    //! The ExtendedFieldURI element identifies an extended MAPI property.
+    class extended_field_uri final
+    {
+    public:
+        //! \brief Represents the <tt>\<PropertySetId\></tt> of an
+        //! <tt>\<ExtendedFieldUri\></tt>.
+        //!
+        //! Defines the well-known property set IDs for extended MAPI
+        //! properties. If this attribute is used, the PropertySetId and
+        //! PropertyTag attributes cannot be used. This attribute must be
+        //! used with either the PropertyId or PropertyName attribute, and
+        //! the PropertyType attribute. The DistinguishedPropertySetId
+        //! Attribute table later in this topic lists the possible values
+        //! for this attribute. This attribute is optional.
+        class distinguished_property_set_id final
+        {
+        public:
+//! Default constructor
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+            distinguished_property_set_id() = default;
+#else
+            distinguished_property_set_id(){}
+#endif
+            //! Constructor to create an DistinguishedPropertySetId property
+            explicit distinguished_property_set_id(std::string str)
+                : str_(std::move(str)){}
+
+            //! Returns this property as a string.
+            const std::string& str() const EWS_NOEXCEPT { return str_; }
+
+        private:
+            std::string str_;
+        };
+
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+        static_assert(
+            std::is_default_constructible<distinguished_property_set_id>::value,
+            "");
+        static_assert(
+            std::is_copy_constructible<distinguished_property_set_id>::value,
+            "");
+        static_assert(
+            std::is_copy_assignable<distinguished_property_set_id>::value, "");
+        static_assert(
+            std::is_move_constructible<distinguished_property_set_id>::value,
+            "");
+        static_assert(
+            std::is_move_assignable<distinguished_property_set_id>::value, "");
+#endif
+
+        //! \brief Represents the <tt>\<PropertySetId\></tt> of an
+        //! <tt>\<ExtendedFieldUri\></tt>.
+        //!
+        //! Identifies a MAPI extended property set or namespace by its
+        //! identifying GUID. If this attribute is used, the
+        //! DistinguishedPropertySetId and PropertyTag attribute cannot be used.
+        //! This attribute must be used with either the PropertyId or
+        //! PropertyName attribute, and the PropertyType attribute.
+        //! This attribute is optional.
+        class property_set_id final
+        {
+        public:
+//! Default constructor
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+            property_set_id() = default;
+#else
+            property_set_id(){}
+#endif
+            //! Constructor to create a PropertySetId property
+            explicit property_set_id(std::string str) : str_(std::move(str)){}
+
+            //! Returns this property as a string.
+            const std::string& str() const EWS_NOEXCEPT { return str_; }
+
+        private:
+            std::string str_;
+        };
+
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+        static_assert(std::is_default_constructible<property_set_id>::value,
+                      "");
+        static_assert(std::is_copy_constructible<property_set_id>::value, "");
+        static_assert(std::is_copy_assignable<property_set_id>::value, "");
+        static_assert(std::is_move_constructible<property_set_id>::value, "");
+        static_assert(std::is_move_assignable<property_set_id>::value, "");
+#endif
+
+        //! \brief Represents the <tt>\<PropertyTag\></tt> of an
+        //! <tt>\<ExtendedFieldUri\></tt>.
+        //!
+        //! Identifies the property tag without the type part of the tag.
+        //! The PropertyTag can be represented as either a hexadecimal or a
+        //! short integer. The range between 0x8000 and 0xFFFE represents the
+        //! custom range of properties. When a mailbox database encounters a
+        //! custom property for the first time, it assigns that custom property
+        //! a property tag within the custom property range of 0x8000-0xFFFE.
+        //! A given custom property tag will most likely differ across
+        //! databases.
+        //! Therefore, a custom property request by property tag can return
+        //! different properties on different databases. The use of the
+        //! PropertyTag attribute is prohibited for custom properties.
+        //! Instead, use the PropertySetId attribute and the PropertyName
+        //! or PropertyId attribute.
+        //! If the PropertyTag attribute is used, the
+        //! DistinguishedPropertySetId,
+        //! PropertySetId, PropertyName, and PropertyId attributes cannot be
+        //! used.
+        //! This attribute is optional.
+        class property_tag final
+        {
+        public:
+//! Default constructor
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+            property_tag() = default;
+#else
+            property_tag(){}
+#endif
+            //! Constructor to create a PropertyTag property
+            explicit property_tag(std::string str) : str_(std::move(str)){}
+
+            //! Returns this property as a string.
+            const std::string& str() const EWS_NOEXCEPT { return str_; }
+
+        private:
+            std::string str_;
+        };
+
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+        static_assert(std::is_default_constructible<property_tag>::value, "");
+        static_assert(std::is_copy_constructible<property_tag>::value, "");
+        static_assert(std::is_copy_assignable<property_tag>::value, "");
+        static_assert(std::is_move_constructible<property_tag>::value, "");
+        static_assert(std::is_move_assignable<property_tag>::value, "");
+#endif
+
+        //! \brief Represents the <tt>\<PropertyName\></tt> of an
+        //! <tt>\<ExtendedFieldUri\></tt>.
+        //!
+        //! Identifies an extended property by its name.
+        //! This property must be coupled with either DistinguishedPropertySetId
+        //! or PropertySetId.
+        //! If this attribute is used, the PropertyId and PropertyTag attributes
+        //! cannot be used. This attribute is optional.
+        class property_name final
+        {
+        public:
+//! Default constructor
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+            property_name() = default;
+#else
+            property_name(){}
+#endif
+            //! Constructor to create a PropertyTag property
+            explicit property_name(std::string str) : str_(std::move(str)){}
+
+            //! Returns this property as a string.
+            const std::string& str() const EWS_NOEXCEPT { return str_; }
+
+        private:
+            std::string str_;
+        };
+
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+        static_assert(std::is_default_constructible<property_name>::value, "");
+        static_assert(std::is_copy_constructible<property_name>::value, "");
+        static_assert(std::is_copy_assignable<property_name>::value, "");
+        static_assert(std::is_move_constructible<property_name>::value, "");
+        static_assert(std::is_move_assignable<property_name>::value, "");
+#endif
+
+        //! \brief Represents the <tt>\<PropertyId\></tt> of an
+        //! <tt>\<ExtendedFieldUri\></tt>.
+        //!
+        //! Identifies an extended property by its dispatch ID. The dispatch ID
+        //! can be identified in either decimal or hexadecimal formats.
+        //! This property must be coupled with either DistinguishedPropertySetId
+        //! or PropertySetId. If this attribute is used, the PropertyName and
+        //! PropertyTag attributes cannot be used. This attribute is optional.
+        class property_id final
+        {
+        public:
+//! Default constructor
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+            property_id() = default;
+#else
+            property_id(){}
+#endif
+            //! Constructor to create a PropertyId property
+            explicit property_id(std::string str) : str_(std::move(str)){}
+
+            //! Returns this property as a string.
+            const std::string& str() const EWS_NOEXCEPT { return str_; }
+
+        private:
+            std::string str_;
+        };
+
+        //! \brief Represents the <tt>\<PropertyType\></tt> of an
+        //! <tt>\<ExtendedFieldUri\></tt>.
+        //!
+        //! Represents the property type of a property tag. This corresponds
+        //! to the least significant word in a property tag. The PropertyType
+        //! Attribute table later in this topic contains the possible values
+        //! for this attribute. This attribute is required.
+        class property_type final
+        {
+        public:
+//! Default constructor
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+            property_type() = default;
+#else
+            property_type(){}
+#endif
+            //! Constructor to create a PropertyType property
+            explicit property_type(std::string str) : str_(std::move(str)){}
+
+            //! Returns this property as a string.
+            const std::string& str() const EWS_NOEXCEPT { return str_; }
+
+            extended_field_uri
+            form_xml_element(const rapidxml::xml_node<>& elem);
+
+        private:
+            std::string str_;
+        };
+
+        //! \brief Constructor for initialization based on
+        //! distinguished_property_set_id
+        //! and property_id
+        extended_field_uri(
+            distinguished_property_set_id distinguished_property_set_id,
+            property_id property_id, property_type property_type)
+            : distinguished_property_set_id_(
+                  std::move(distinguished_property_set_id)),
+              property_id_(std::move(property_id)),
+              property_type_(std::move(property_type))
+        {
+        }
+
+        //! \brief Constructor for initialization based on
+        //! distinguished_property_set_id
+        //! and property_name
+        extended_field_uri(
+            distinguished_property_set_id distinguished_property_set_id,
+            std::string property_name, property_type property_type)
+            : distinguished_property_set_id_(
+                  std::move(distinguished_property_set_id)),
+              property_name_(std::move(property_name)),
+              property_type_(std::move(property_type))
+        {
+        }
+
+        //! \brief Constructor for initialization based on property_set_id
+        //! and poperty_id
+        extended_field_uri(property_set_id property_set_id,
+                           property_id property_id, property_type property_type)
+            : property_set_id_(std::move(property_set_id)),
+              property_id_(std::move(property_id)),
+              property_type_(std::move(property_type))
+        {
+        }
+
+        //! \brief Constructor for initialization based on property_set_id
+        //! and property_name
+        extended_field_uri(property_set_id property_set_id,
+                           std::string property_name,
+                           property_type property_type)
+            : property_set_id_(std::move(property_set_id)),
+              property_name_(std::move(property_name)),
+              property_type_(std::move(property_type))
+        {
+        }
+
+        //! \brief Constructor for initialization based on property_tag
+        extended_field_uri(property_tag property_tag,
+                           property_type property_type)
+            : property_tag_(std::move(property_tag)),
+              property_type_(std::move(property_type))
+        {
+        }
+
+        //! Returns the <tt>\<DistinguishedPropertySetId\></tt> as a std::string
+        const std::string&
+        get_distinguished_property_set_id() const EWS_NOEXCEPT
+        {
+            return distinguished_property_set_id_.str();
+        }
+
+        //! Returns the <tt>\<PropertySetId\></tt> as a std::string
+        const std::string& get_property_set_id() const EWS_NOEXCEPT
+        {
+            return property_set_id_.str();
+        }
+
+        //! Returns the <tt>\<PropertyTag\></tt> as a std::string
+        const std::string& get_property_tag() const EWS_NOEXCEPT
+        {
+            return property_tag_.str();
+        }
+
+        //! Returns the <tt>\<PropertyName\></tt> as a std::string
+        const std::string& get_property_name() const EWS_NOEXCEPT
+        {
+            return property_name_.str();
+        }
+
+        //! Returns the <tt>\<PropertyId\></tt> as a std::string
+        const std::string& get_property_id() const EWS_NOEXCEPT
+        {
+            return property_id_.str();
+        }
+
+        //! Returns the <tt>\<PropertyType\></tt> as a std::string
+        const std::string& get_property_type() const EWS_NOEXCEPT
+        {
+            return property_type_.str();
+        }
+
+        //! Sets a <tt>\<DistinguishedPropertySetId\></tt>
+        void set_distinguished_property_set_id(
+            const distinguished_property_set_id& dpsi)
+        {
+            distinguished_property_set_id_ = dpsi;
+        }
+
+        //! Sets a <tt>\<PropertySetId\></tt>
+        void set_property_set_id(const property_set_id& psi)
+        {
+            property_set_id_ = psi;
+        }
+
+        //! Sets a <tt>\<PropertyTag\></tt>
+        void set_property_tag(const property_tag& ptg) { property_tag_ = ptg; }
+
+        //! Sets a <tt>\<PropertyName\></tt>
+        void set_property_name(const property_name& pn) { property_name_ = pn; }
+
+        //! Sets a <tt>\<PropertyId\></tt>
+        void set_property_id(const property_id& pi) { property_id_ = pi; }
+
+        //! Sets a <tt>\<PropertyType\></tt>
+        void set_property_type(const property_type& pt) { property_type_ = pt; }
+
+        //! Converts an extended_field_uri into a xml string.
+        std::string to_xml()
+        {
+            std::stringstream sstr;
+
+            sstr << "<t:ExtendedFieldURI ";
+
+            if (!distinguished_property_set_id_.str().empty())
+            {
+                sstr << "DistinguishedPropertySetId=\""
+                     << distinguished_property_set_id_.str() << "\" ";
+            }
+            if (!property_id_.str().empty())
+            {
+                sstr << "PropertyId=\"" << property_id_.str() << "\" ";
+            }
+            if (!property_set_id_.str().empty())
+            {
+                sstr << "PropertySetId=\"" << property_set_id_.str() << "\" ";
+            }
+            if (!property_tag_.str().empty())
+            {
+                sstr << "PropertyTag=\"" << property_tag_.str() << "\" ";
+            }
+            if (!property_name_.str().empty())
+            {
+                sstr << "PropertyName=\"" << property_name_.str() << "\" ";
+            }
+            if (!property_type_.str().empty())
+            {
+                sstr << "PropertyType=\"" << property_type_.str() << "\"/>";
+            }
+            return sstr.str();
+        }
+
+        //! Converts an xml string into a extended_field_uri property.
+        static extended_field_uri
+        from_xml_element(const rapidxml::xml_node<>& elem)
+        {
+            extended_field_uri ext_field_uri;
+
+            for (auto attr = elem.first_attribute(); attr != nullptr;
+                 attr = attr->next_attribute())
+            {
+                if (std::string(attr->name(), attr->name_size()) ==
+                    "DistinguishedPropertySetId")
+                {
+                    ext_field_uri.set_distinguished_property_set_id(
+                        distinguished_property_set_id(
+                            std::string(attr->value(), attr->value_size())));
+                }
+                else if (std::string(attr->name(), attr->name_size()) ==
+                         "PropertySetId")
+                {
+                    ext_field_uri.set_property_set_id(property_set_id(
+                        std::string(attr->value(), attr->value_size())));
+                }
+                else if (std::string(attr->name(), attr->name_size()) ==
+                         "PropertyTag")
+                {
+                    ext_field_uri.set_property_tag(property_tag(
+                        std::string(attr->value(), attr->value_size())));
+                }
+                else if (std::string(attr->name(), attr->name_size()) ==
+                         "PropertyName")
+                {
+                    ext_field_uri.set_property_name(property_name(
+                        std::string(attr->value(), attr->value_size())));
+                }
+                else if (std::string(attr->name(), attr->name_size()) ==
+                         "PropertyId")
+                {
+                    ext_field_uri.set_property_id(property_id(
+                        std::string(attr->value(), attr->value_size())));
+                }
+                else if (std::string(attr->name(), attr->name_size()) ==
+                         "PropertyType")
+                {
+                    ext_field_uri.set_property_type(property_type(
+                        std::string(attr->value(), attr->value_size())));
+                }
+                else
+                {
+                    throw exception(
+                        "Unexpected child element in <ExtendedFieldURI>");
+                }
+            }
+
+            // Validate and constructor selection
+            if (ext_field_uri.get_property_type().empty())
+            {
+                throw exception(
+                    "Invalid empty <PropertyType> in <ExtendedFieldURI>");
+            }
+            return ext_field_uri;
+        }
+
+        //! Converts a xml string into a extended_field_uri rapidxml
+        //! representation.
+        rapidxml::xml_node<>& to_xml_element(rapidxml::xml_node<>& parent)
+        {
+            auto doc = parent.document();
+            rapidxml::xml_attribute<>* attr_new;
+
+            auto new_node = doc->allocate_node(rapidxml::node_element,
+                                               "t:ExtendedFieldURI");
+            new_node->namespace_uri(internal::uri<>::microsoft::types(),
+                                    internal::uri<>::microsoft::types_size);
+
+            if (!get_distinguished_property_set_id().empty())
+            {
+                attr_new = doc->allocate_attribute(
+                    "DistinguishedPropertySetId",
+                    get_distinguished_property_set_id().c_str());
+                new_node->append_attribute(attr_new);
+            }
+            if (!get_property_set_id().empty())
+            {
+                attr_new = doc->allocate_attribute(
+                    "PropertySetId", get_property_set_id().c_str());
+                new_node->append_attribute(attr_new);
+            }
+            if (!get_property_tag().empty())
+            {
+                attr_new = doc->allocate_attribute("PropertyTag",
+                                                   get_property_tag().c_str());
+                new_node->append_attribute(attr_new);
+            }
+            if (!get_property_name().empty())
+            {
+                attr_new = doc->allocate_attribute("PropertyName",
+                                                   get_property_name().c_str());
+                new_node->append_attribute(attr_new);
+            }
+            if (!get_property_type().empty())
+            {
+                attr_new = doc->allocate_attribute("PropertyType",
+                                                   get_property_type().c_str());
+                new_node->append_attribute(attr_new);
+            }
+            if (!get_property_id().empty())
+            {
+                attr_new = doc->allocate_attribute("PropertyId",
+                                                   get_property_id().c_str());
+                new_node->append_attribute(attr_new);
+            }
+
+            parent.append_node(new_node);
+
+            return *new_node;
+        }
+
+    private:
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+        extended_field_uri() = default;
+#else
+        extended_field_uri() {}
+#endif
+        distinguished_property_set_id distinguished_property_set_id_;
+        property_set_id property_set_id_;
+        property_tag property_tag_;
+        property_name property_name_;
+        property_id property_id_;
+        property_type property_type_;
+    };
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+    static_assert(!std::is_default_constructible<extended_field_uri>::value,
+                  "");
+    static_assert(std::is_copy_constructible<extended_field_uri>::value, "");
+    static_assert(std::is_copy_assignable<extended_field_uri>::value, "");
+    static_assert(std::is_move_constructible<extended_field_uri>::value, "");
+    static_assert(std::is_move_assignable<extended_field_uri>::value, "");
+#endif
+
+    //! \brief Represents an <tt>\<ExtendedProperty\><tt>
+    //
+    //! The ExtendedProperty element identifies extended MAPI properties on
+    //! folders and items. Extended properties enable Microsoft Exchange Server
+    //! clients to add customized properties to items and folders that are
+    //! stored in an Exchange mailbox. Custom properties can be used to store
+    //! data that is relevant to an object.
+    class extended_property final
+    {
+    public:
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+        extended_property() = delete;
+#else
+        extended_property() {}
+#endif
+        //! \brief Constructor to initialize an <tt>\<ExtendedProperty\><tt>
+        //! with the
+        //! neccessary values
+        extended_property(extended_field_uri ext_field_uri,
+                          std::vector<std::string> values)
+            : extended_field_uri_(std::move(ext_field_uri)),
+              values_(std::move(values))
+        {
+        }
+
+        //! Returns the the extended_field_uri element of this
+        //! extended_property.
+        const extended_field_uri& get_extended_field_uri() const EWS_NOEXCEPT
+        {
+            return extended_field_uri_;
+        }
+
+        //! \brief Returns the values of the extended_property as a vector
+        //! even it is just one
+        const std::vector<std::string>& get_values() const EWS_NOEXCEPT
+        {
+            return values_;
+        }
+
+    private:
+        extended_field_uri extended_field_uri_;
+        std::vector<std::string> values_;
+    };
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+    static_assert(!std::is_default_constructible<extended_property>::value, "");
+    static_assert(std::is_copy_constructible<extended_property>::value, "");
+    static_assert(std::is_copy_assignable<extended_property>::value, "");
+    static_assert(std::is_move_constructible<extended_property>::value, "");
+    static_assert(std::is_move_assignable<extended_property>::value, "");
+#endif
+
     //! Represents a generic <tt>\<Item></tt> in the Exchange store
     class item
     {
@@ -7974,9 +8542,91 @@ namespace ews
             return xml().get_value_as_string("HasAttachments") == "true";
         }
 
-        // List of zero or more extended properties that are requested for
-        // this item
-        // TODO: get_extended_property
+        //! List of zero or more extended properties that are requested for
+        //! an item
+        std::vector<extended_property> get_extended_properties() const
+        {
+            std::vector<extended_property> vep;
+
+            for (auto top_node = xml().get_node("ExtendedProperty");
+                 top_node != nullptr; top_node = top_node->next_sibling())
+            {
+                if (std::string(top_node->name(), top_node->name_size()) !=
+                    "t:ExtendedProperty")
+                    continue;
+
+                for (auto ep_node = top_node->first_node(); ep_node != nullptr;
+                     ep_node = ep_node->next_sibling())
+                {
+                    auto ext_field_uri =
+                        extended_field_uri::from_xml_element(*ep_node);
+
+                    std::vector<std::string> values;
+                    ep_node = ep_node->next_sibling(); // go to value(es)
+
+                    if (std::string(ep_node->name(), ep_node->name_size()) ==
+                        "t:Value")
+                    {
+                        values.emplace_back(std::string(ep_node->value(),
+                                                        ep_node->value_size()));
+                    }
+                    else if (std::string(ep_node->name(),
+                                         ep_node->name_size()) == "t:Values")
+                    {
+                        for (auto node = ep_node->first_node(); node != nullptr;
+                             node = node->next_sibling())
+                        {
+                            values.emplace_back(
+                                std::string(node->value(), node->value_size()));
+                        }
+                    }
+                    vep.emplace_back(extended_property(ext_field_uri, values));
+                }
+            }
+            return vep;
+        }
+
+        void set_extended_property(const extended_property& extended_prop)
+        {
+            auto doc = xml().document();
+
+            auto ptr_to_qname = doc->allocate_string("t:ExtendedProperty");
+            auto top_node = doc->allocate_node(rapidxml::node_element);
+            top_node->qname(ptr_to_qname, std::strlen("t:ExtendedProperty"),
+                            ptr_to_qname + 2);
+            top_node->namespace_uri(internal::uri<>::microsoft::types(),
+                                    internal::uri<>::microsoft::types_size);
+            doc->append_node(top_node);
+
+            extended_field_uri field_uri =
+                extended_prop.get_extended_field_uri();
+            field_uri.to_xml_element(*top_node);
+            //top_node->append_node(&new_node);
+
+            rapidxml::xml_node<>* cover_node = nullptr;
+            if (extended_prop.get_values().size() > 1)
+            {
+                cover_node =
+                    doc->allocate_node(rapidxml::node_element, "t:Values");
+                cover_node->namespace_uri(
+                    internal::uri<>::microsoft::types(),
+                    internal::uri<>::microsoft::types_size);
+                top_node->append_node(cover_node);
+            }
+
+            for (auto str : extended_prop.get_values())
+            {
+                auto new_str = doc->allocate_string(str.c_str());
+                auto cur_node =
+                    doc->allocate_node(rapidxml::node_element, "t:Value");
+                cur_node->namespace_uri(internal::uri<>::microsoft::types(),
+                                        internal::uri<>::microsoft::types_size);
+                cur_node->value(new_str);
+
+                cover_node == nullptr ? top_node->append_node(cur_node)
+                                      : cover_node->append_node(cur_node);
+            }
+        }
 
         //! Sets the culture name associated with the body of this item
         void set_culture(const std::string& culture)
@@ -12441,6 +13091,12 @@ namespace ews
             return get_item_impl<message>(id, base_shape::all_properties,
                                           additional_properties);
         }
+        message
+        get_message(const item_id& id,
+                    const std::vector<extended_field_uri>& ext_field_uri)
+        {
+            return get_item_impl<message>(id, ext_field_uri);
+        }
 
         //! Delete an arbitrary item from the Exchange store
         void delete_item(const item_id& id,
@@ -12973,6 +13629,41 @@ namespace ews
             for (const auto& prop : additional_properties)
             {
                 sstr << "<t:FieldURI FieldURI=\"" << prop.field_uri() << "\"/>";
+            }
+            sstr << "</t:AdditionalProperties>"
+                    "</m:ItemShape>"
+                    "<m:ItemIds>"
+                 << id.to_xml() << "</m:ItemIds>"
+                                   "</m:GetItem>";
+
+            auto response = request(sstr.str());
+            const auto response_message =
+                internal::get_item_response_message<ItemType>::parse(
+                    std::move(response));
+            if (!response_message.success())
+            {
+                throw exchange_error(response_message.get_response_code());
+            }
+            EWS_ASSERT(!response_message.items().empty() &&
+                       "Expected at least one item");
+            return response_message.items().front();
+        }
+
+        template <typename ItemType>
+        ItemType
+        get_item_impl(const item_id& id,
+                      const std::vector<extended_field_uri>& ext_field_uris)
+        {
+            EWS_ASSERT(!ext_field_uris.empty());
+
+            std::stringstream sstr;
+            sstr << "<m:GetItem>"
+                    "<m:ItemShape>"
+                    "<t:BaseShape>AllProperties</t:BaseShape>"
+                    "<t:AdditionalProperties>";
+            for (auto item : ext_field_uris)
+            {
+                sstr << item.to_xml();
             }
             sstr << "</t:AdditionalProperties>"
                     "</m:ItemShape>"

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -7504,7 +7504,10 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
         internet_message_header() = delete;
 #else
+    private:
         internet_message_header() {}
+
+    public:
 #endif
         //! Constructs a header filed with given values
         internet_message_header(std::string name, std::string value)
@@ -8090,7 +8093,10 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
         extended_property() = delete;
 #else
+    private:
         extended_property() {}
+
+    public:
 #endif
         //! \brief Constructor to initialize an <tt>\<ExtendedProperty\></tt>
         //! with the

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -7561,11 +7561,13 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
             distinguished_property_set_id() = default;
 #else
-            distinguished_property_set_id(){}
+            distinguished_property_set_id() {}
 #endif
             //! Constructor to create an DistinguishedPropertySetId property
             explicit distinguished_property_set_id(std::string str)
-                : str_(std::move(str)){}
+                : str_(std::move(str))
+            {
+            }
 
             //! Returns this property as a string.
             const std::string& str() const EWS_NOEXCEPT { return str_; }
@@ -7606,10 +7608,10 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
             property_set_id() = default;
 #else
-            property_set_id(){}
+            property_set_id() {}
 #endif
             //! Constructor to create a PropertySetId property
-            explicit property_set_id(std::string str) : str_(std::move(str)){}
+            explicit property_set_id(std::string str) : str_(std::move(str)) {}
 
             //! Returns this property as a string.
             const std::string& str() const EWS_NOEXCEPT { return str_; }
@@ -7655,10 +7657,10 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
             property_tag() = default;
 #else
-            property_tag(){}
+            property_tag() {}
 #endif
             //! Constructor to create a PropertyTag property
-            explicit property_tag(std::string str) : str_(std::move(str)){}
+            explicit property_tag(std::string str) : str_(std::move(str)) {}
 
             //! Returns this property as a string.
             const std::string& str() const EWS_NOEXCEPT { return str_; }
@@ -7690,10 +7692,10 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
             property_name() = default;
 #else
-            property_name(){}
+            property_name() {}
 #endif
             //! Constructor to create a PropertyTag property
-            explicit property_name(std::string str) : str_(std::move(str)){}
+            explicit property_name(std::string str) : str_(std::move(str)) {}
 
             //! Returns this property as a string.
             const std::string& str() const EWS_NOEXCEPT { return str_; }
@@ -7725,10 +7727,10 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
             property_id() = default;
 #else
-            property_id(){}
+            property_id() {}
 #endif
             //! Constructor to create a PropertyId property
-            explicit property_id(std::string str) : str_(std::move(str)){}
+            explicit property_id(std::string str) : str_(std::move(str)) {}
 
             //! Returns this property as a string.
             const std::string& str() const EWS_NOEXCEPT { return str_; }
@@ -7751,10 +7753,10 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
             property_type() = default;
 #else
-            property_type(){}
+            property_type() {}
 #endif
             //! Constructor to create a PropertyType property
-            explicit property_type(std::string str) : str_(std::move(str)){}
+            explicit property_type(std::string str) : str_(std::move(str)) {}
 
             //! Returns this property as a string.
             const std::string& str() const EWS_NOEXCEPT { return str_; }
@@ -7982,51 +7984,69 @@ namespace ews
 
         //! Converts a xml string into a extended_field_uri rapidxml
         //! representation.
-        rapidxml::xml_node<>& to_xml_element(rapidxml::xml_node<>& parent)
+        rapidxml::xml_node<>& to_xml_element(rapidxml::xml_node<>& parent) const
         {
             auto doc = parent.document();
-            rapidxml::xml_attribute<>* attr_new;
 
-            auto new_node = doc->allocate_node(rapidxml::node_element,
-                                               "t:ExtendedFieldURI");
+            auto ptr_to_node = doc->allocate_string("t:ExtendedFieldURI");
+            auto new_node =
+                doc->allocate_node(rapidxml::node_element, ptr_to_node);
             new_node->namespace_uri(internal::uri<>::microsoft::types(),
                                     internal::uri<>::microsoft::types_size);
 
             if (!get_distinguished_property_set_id().empty())
             {
-                attr_new = doc->allocate_attribute(
-                    "DistinguishedPropertySetId",
+                auto ptr_to_attr =
+                    doc->allocate_string("DistinguishedPropertySetId");
+                auto ptr_to_property = doc->allocate_string(
                     get_distinguished_property_set_id().c_str());
+                auto attr_new =
+                    doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
             if (!get_property_set_id().empty())
             {
-                attr_new = doc->allocate_attribute(
-                    "PropertySetId", get_property_set_id().c_str());
+                auto ptr_to_attr = doc->allocate_string("PropertySetId");
+                auto ptr_to_property =
+                    doc->allocate_string(get_property_set_id().c_str());
+                auto attr_new =
+                    doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
             if (!get_property_tag().empty())
             {
-                attr_new = doc->allocate_attribute("PropertyTag",
-                                                   get_property_tag().c_str());
+                auto ptr_to_attr = doc->allocate_string("PropertyTag");
+                auto ptr_to_property =
+                    doc->allocate_string(get_property_tag().c_str());
+                auto attr_new =
+                    doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
             if (!get_property_name().empty())
             {
-                attr_new = doc->allocate_attribute("PropertyName",
-                                                   get_property_name().c_str());
+                auto ptr_to_attr = doc->allocate_string("PropertyName");
+                auto ptr_to_property =
+                    doc->allocate_string(get_property_name().c_str());
+                auto attr_new =
+                    doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
             if (!get_property_type().empty())
             {
-                attr_new = doc->allocate_attribute("PropertyType",
-                                                   get_property_type().c_str());
+                auto ptr_to_attr = doc->allocate_string("PropertyType");
+                auto ptr_to_property =
+                    doc->allocate_string(get_property_type().c_str());
+                auto attr_new =
+                    doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
             if (!get_property_id().empty())
             {
-                attr_new = doc->allocate_attribute("PropertyId",
-                                                   get_property_id().c_str());
+                auto ptr_to_attr = doc->allocate_string("PropertyId");
+                auto ptr_to_property =
+                    doc->allocate_string(get_property_id().c_str());
+                auto attr_new =
+                    doc->allocate_attribute(ptr_to_attr, ptr_to_property);
                 new_node->append_attribute(attr_new);
             }
 
@@ -8072,7 +8092,7 @@ namespace ews
 #else
         extended_property() {}
 #endif
-        //! \brief Constructor to initialize an <tt>\<ExtendedProperty\><tt>
+        //! \brief Constructor to initialize an <tt>\<ExtendedProperty\></tt>
         //! with the
         //! neccessary values
         extended_property(extended_field_uri ext_field_uri,
@@ -8602,13 +8622,13 @@ namespace ews
             extended_field_uri field_uri =
                 extended_prop.get_extended_field_uri();
             field_uri.to_xml_element(*top_node);
-            //top_node->append_node(&new_node);
 
-            rapidxml::xml_node<>* cover_node = nullptr;
+            rapidxml::xml_node<char>* cover_node = nullptr;
             if (extended_prop.get_values().size() > 1)
             {
+                auto ptr_to_value = doc->allocate_string("t:Value");
                 cover_node =
-                    doc->allocate_node(rapidxml::node_element, "t:Values");
+                    doc->allocate_node(rapidxml::node_element, ptr_to_value);
                 cover_node->namespace_uri(
                     internal::uri<>::microsoft::types(),
                     internal::uri<>::microsoft::types_size);
@@ -8618,8 +8638,9 @@ namespace ews
             for (auto str : extended_prop.get_values())
             {
                 auto new_str = doc->allocate_string(str.c_str());
+                auto ptr_to_value = doc->allocate_string("t:Value");
                 auto cur_node =
-                    doc->allocate_node(rapidxml::node_element, "t:Value");
+                    doc->allocate_node(rapidxml::node_element, ptr_to_value);
                 cur_node->namespace_uri(internal::uri<>::microsoft::types(),
                                         internal::uri<>::microsoft::types_size);
                 cur_node->value(new_str);

--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -155,8 +155,7 @@ namespace tests
     class BaseFixture : public testing::Test
     {
     public:
-        BaseFixture()
-            : assets_(ews::test::global_data::instance().assets_dir)
+        BaseFixture() : assets_(ews::test::global_data::instance().assets_dir)
         {
         }
 

--- a/tests/test_attachments.cpp
+++ b/tests/test_attachments.cpp
@@ -368,8 +368,7 @@ namespace tests
         auto msg = ews::message();
         msg.set_subject("Honorable Minister of Finance - Release Funds");
         std::vector<ews::mailbox> recipients;
-        recipients.push_back(
-            ews::mailbox("udom.emmanuel@zenith-bank.com.ng"));
+        recipients.push_back(ews::mailbox("udom.emmanuel@zenith-bank.com.ng"));
         msg.set_to_recipients(recipients);
         auto item_id =
             service().create_item(msg, ews::message_disposition::save_only);

--- a/tests/test_items.cpp
+++ b/tests/test_items.cpp
@@ -679,6 +679,258 @@ namespace tests
         EXPECT_EQ("", task.get_display_to());
     }
 
+    TEST(OfflineExtendedFieldUriTest, DistPropertySetIdNameRoundTrip)
+    {
+        // 1. based on distinguished_property_set_id and property_name
+        const char* xml = "<t:ExtendedFieldURI "
+                          "DistinguishedPropertySetId=\"PublicStrings\" "
+                          "PropertyName=\"ShoeSize\" "
+                          "PropertyType=\"Float\"/>";
+        std::vector<char> buf(xml, xml + std::strlen(xml));
+        buf.push_back('\0');
+
+        xml_document doc;
+        doc.parse<rapidxml::parse_no_namespace>(&buf[0]);
+        auto node = doc.first_node();
+        auto obj = ews::extended_field_uri::from_xml_element(*node);
+        EXPECT_STREQ("PublicStrings",
+                     obj.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("", obj.get_property_set_id().c_str());
+        EXPECT_STREQ("", obj.get_property_tag().c_str());
+        EXPECT_STREQ("ShoeSize", obj.get_property_name().c_str());
+        EXPECT_STREQ("", obj.get_property_id().c_str());
+        EXPECT_STREQ("Float", obj.get_property_type().c_str());
+    }
+
+    TEST(OfflineExtendedFieldUriTest, DistPropertySetIdIdRoundTrip)
+    {
+        // 2. based on distinguished_property_set_id and property_id
+        const char* xml = "<t:ExtendedFieldURI "
+                          "DistinguishedPropertySetId=\"PublicStrings\" "
+                          "PropertyId=\"42\" "
+                          "PropertyType=\"Boolean\"/>";
+        std::vector<char> buf(xml, xml + std::strlen(xml));
+        buf.push_back('\0');
+
+        xml_document doc;
+        doc.parse<rapidxml::parse_no_namespace>(&buf[0]);
+        auto node = doc.first_node();
+        auto obj = ews::extended_field_uri::from_xml_element(*node);
+        EXPECT_STREQ("PublicStrings",
+                     obj.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("", obj.get_property_set_id().c_str());
+        EXPECT_STREQ("", obj.get_property_tag().c_str());
+        EXPECT_STREQ("", obj.get_property_name().c_str());
+        EXPECT_STREQ("42", obj.get_property_id().c_str());
+        EXPECT_STREQ("Boolean", obj.get_property_type().c_str());
+    }
+    TEST(OfflineExtendedFieldUriTest, PropertySetIdIdRoundTrip)
+    {
+        // 3. based on property_set_id and property_id
+        const char* xml =
+            "<t:ExtendedFieldURI "
+            "PropertySetId=\"24040483-cda4-4521-bb5f-a83fac4d19a4\" "
+            "PropertyId=\"2\" "
+            "PropertyType=\"IntegerArray\"/>";
+        std::vector<char> buf(xml, xml + std::strlen(xml));
+        buf.push_back('\0');
+
+        xml_document doc;
+        doc.parse<rapidxml::parse_no_namespace>(&buf[0]);
+        auto node = doc.first_node();
+        auto obj = ews::extended_field_uri::from_xml_element(*node);
+        EXPECT_STREQ("", obj.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("24040483-cda4-4521-bb5f-a83fac4d19a4",
+                     obj.get_property_set_id().c_str());
+        EXPECT_STREQ("", obj.get_property_tag().c_str());
+        EXPECT_STREQ("", obj.get_property_name().c_str());
+        EXPECT_STREQ("2", obj.get_property_id().c_str());
+        EXPECT_STREQ("IntegerArray", obj.get_property_type().c_str());
+    }
+    TEST(OfflineExtendedFieldUriTest, PropertySetIdNameRoundTrip)
+    {
+        // 4. based on property_set_id and property_name
+        const char* xml =
+            "<t:ExtendedFieldURI "
+            "PropertySetId=\"24040483-cda4-4521-bb5f-a83fac4d19a4\" "
+            "PropertyName=\"Rumpelstiltskin\" "
+            "PropertyType=\"Integer\"/>";
+        std::vector<char> buf(xml, xml + std::strlen(xml));
+        buf.push_back('\0');
+
+        xml_document doc;
+        doc.parse<rapidxml::parse_no_namespace>(&buf[0]);
+        auto node = doc.first_node();
+        auto obj = ews::extended_field_uri::from_xml_element(*node);
+        EXPECT_STREQ("", obj.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("24040483-cda4-4521-bb5f-a83fac4d19a4",
+                     obj.get_property_set_id().c_str());
+        EXPECT_STREQ("", obj.get_property_tag().c_str());
+        EXPECT_STREQ("Rumpelstiltskin", obj.get_property_name().c_str());
+        EXPECT_STREQ("", obj.get_property_id().c_str());
+        EXPECT_STREQ("Integer", obj.get_property_type().c_str());
+    }
+
+    TEST(OfflineExtendedFieldUriTest, PropertyTagRoundTrip)
+    {
+        // 5. based on property_tag
+        const char* xml = "<t:ExtendedFieldURI "
+                          "PropertyTag=\"0x0036\" "
+                          "PropertyType=\"Binary\"/>";
+        std::vector<char> buf(xml, xml + std::strlen(xml));
+        buf.push_back('\0');
+
+        xml_document doc;
+        doc.parse<rapidxml::parse_no_namespace>(&buf[0]);
+        auto node = doc.first_node();
+        auto obj = ews::extended_field_uri::from_xml_element(*node);
+        EXPECT_STREQ("", obj.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("", obj.get_property_set_id().c_str());
+        EXPECT_STREQ("0x0036", obj.get_property_tag().c_str());
+        EXPECT_STREQ("", obj.get_property_name().c_str());
+        EXPECT_STREQ("", obj.get_property_id().c_str());
+        EXPECT_STREQ("Binary", obj.get_property_type().c_str());
+    }
+
+    TEST(OfflineExtendedPropertyTest, ExtendedProperty)
+    {
+        auto msg = ews::message();
+
+        std::vector<std::string> values;
+        values.push_back("a lonesome violine string");
+
+        ews::extended_field_uri field_uri(
+            ews::extended_field_uri::property_set_id(
+                "24040483-cda4-4521-bb5f-a83fac4d19a4"),
+            ews::extended_field_uri::property_id("2"),
+            ews::extended_field_uri::property_type("String"));
+
+        ews::extended_property prop(field_uri, values);
+        msg.set_extended_property(prop); // properties are set
+
+        auto ep_actual = msg.get_extended_properties();
+        ASSERT_FALSE(ep_actual.empty());
+        auto efu_actual = ep_actual[0].get_extended_field_uri();
+
+        EXPECT_STREQ("",
+                     efu_actual.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("24040483-cda4-4521-bb5f-a83fac4d19a4",
+                     efu_actual.get_property_set_id().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_tag().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_name().c_str());
+        EXPECT_STREQ("2", efu_actual.get_property_id().c_str());
+        EXPECT_STREQ("String", efu_actual.get_property_type().c_str());
+
+        msg = ews::message(); // ???
+        field_uri = ews::extended_field_uri(
+            ews::extended_field_uri::property_tag("0x0036"),
+            ews::extended_field_uri::property_type("Integer"));
+
+        prop = ews::extended_property(field_uri, values);
+        msg.set_extended_property(prop);
+        ep_actual = msg.get_extended_properties();
+        ASSERT_FALSE(ep_actual.empty());
+        efu_actual = ep_actual[0].get_extended_field_uri();
+
+        EXPECT_STREQ("",
+                     efu_actual.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_set_id().c_str());
+        EXPECT_STREQ("0x0036", efu_actual.get_property_tag().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_name().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_id().c_str());
+        EXPECT_STREQ("Integer", efu_actual.get_property_type().c_str());
+    }
+
+    TEST_F(ItemTest, ExtendedProperty)
+    {
+        auto msg =
+            ews::message(); // see book "Exchange Server 2007 - EWS" p.538
+
+        // Set some constructors, send and get the properties back from Server
+        // 1. based on property_set_id and property_id
+        std::vector<ews::extended_field_uri> all_field_uri;
+        ews::extended_field_uri field_uri1(
+            ews::extended_field_uri::property_set_id(
+                "24040483-cda4-4521-bb5f-a83fac4d19a4"),
+            ews::extended_field_uri::property_id("2"),
+            ews::extended_field_uri::property_type("StringArray"));
+        std::vector<std::string> values;
+        values.push_back("first string");
+        values.push_back("second string");
+        values.push_back("third string");
+        ews::extended_property prop(field_uri1, values);
+        msg.set_extended_property(prop);
+        // 2. based on property_tag
+        values.clear();
+        values.push_back("12345");
+        ews::extended_field_uri field_uri2(
+            ews::extended_field_uri::property_tag("0x0036"),
+            ews::extended_field_uri::property_type("Integer"));
+        prop = ews::extended_property(field_uri2, values);
+        msg.set_extended_property(prop);
+        // 3. based on distinguished_property_set_id and property_name
+        values.clear();
+        values.push_back("12");
+        ews::extended_field_uri field_uri3(
+            ews::extended_field_uri::distinguished_property_set_id(
+                "PublicStrings"),
+            "ShoeSize", ews::extended_field_uri::property_type("Float"));
+        prop = ews::extended_property(field_uri3, values);
+        msg.set_extended_property(prop);
+
+        auto item_id = service().create_item(
+            msg,                                  // message with all properties
+            ews::message_disposition::save_only); // created
+
+        ews::internal::on_scope_exit remove_msg(
+            [&] // make sure to remove msg
+            { service().delete_message(std::move(msg)); });
+        // set all field_uris we want to receive
+        all_field_uri.push_back(field_uri1);
+        all_field_uri.push_back(field_uri2);
+        all_field_uri.push_back(field_uri3);
+        msg = service().get_message(item_id, all_field_uri);
+
+        auto ep_actual = msg.get_extended_properties();
+        ASSERT_TRUE(ep_actual.size() == 3);
+
+        auto efu_actual = ep_actual[0].get_extended_field_uri();
+        EXPECT_STREQ("first string", ep_actual[0].get_values()[0].c_str());
+        EXPECT_STREQ("second string", ep_actual[0].get_values()[1].c_str());
+        EXPECT_STREQ("third string", ep_actual[0].get_values()[2].c_str());
+        EXPECT_STREQ("",
+                     efu_actual.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("24040483-cda4-4521-bb5f-a83fac4d19a4",
+                     efu_actual.get_property_set_id().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_tag().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_name().c_str());
+        EXPECT_STREQ("2", efu_actual.get_property_id().c_str());
+        EXPECT_STREQ("StringArray", efu_actual.get_property_type().c_str());
+
+        efu_actual = ep_actual[1].get_extended_field_uri();
+        EXPECT_STREQ("12345", ep_actual[1].get_values()[0].c_str());
+        EXPECT_STREQ("",
+                     efu_actual.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_set_id().c_str());
+        EXPECT_STREQ("0x36", efu_actual.get_property_tag().c_str()); // Exchange
+                                                                     // removes
+                                                                     // leading
+                                                                     // zeroes
+        EXPECT_STREQ("", efu_actual.get_property_name().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_id().c_str());
+        EXPECT_STREQ("Integer", efu_actual.get_property_type().c_str());
+
+        efu_actual = ep_actual[2].get_extended_field_uri();
+        EXPECT_STREQ("12", ep_actual[2].get_values()[0].c_str());
+        EXPECT_STREQ("PublicStrings",
+                     efu_actual.get_distinguished_property_set_id().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_set_id().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_tag().c_str());
+        EXPECT_STREQ("ShoeSize", efu_actual.get_property_name().c_str());
+        EXPECT_STREQ("", efu_actual.get_property_id().c_str());
+        EXPECT_STREQ("Float", efu_actual.get_property_type().c_str());
+    }
+
     TEST(OfflineItemTest, CulturePropertyDefaultConstructed)
     {
         auto task = ews::task();

--- a/tests/test_items.cpp
+++ b/tests/test_items.cpp
@@ -874,7 +874,8 @@ namespace tests
         ews::extended_field_uri field_uri3(
             ews::extended_field_uri::distinguished_property_set_id(
                 "PublicStrings"),
-            "ShoeSize", ews::extended_field_uri::property_type("Float"));
+            ews::extended_field_uri::property_name("ShoeSize"),
+            ews::extended_field_uri::property_type("Float"));
         prop = ews::extended_property(field_uri3, values);
         msg.set_extended_property(prop);
 

--- a/tests/test_service.cpp
+++ b/tests/test_service.cpp
@@ -268,8 +268,8 @@ namespace tests
         additional_recipients.push_back(ews::mailbox("gus.goose@duckburg.com"));
         auto prop = ews::property(ews::message_property_path::to_recipients,
                                   additional_recipients);
-        auto change = ews::update(prop,
-                                  ews::update::operation::append_to_item_field);
+        auto change =
+            ews::update(prop, ews::update::operation::append_to_item_field);
         auto new_id = service().update_item(message.get_item_id(), change);
         message = service().get_message(item_id);
         ASSERT_EQ(2U, message.get_to_recipients().size());


### PR DESCRIPTION
This commit implements the class extended_property which holds the class extended_field_uri as member containing the following attributes:
- distinguished_property_set_id
- property_set_id
- property_tag
- property_id
- property_type

There are five constructors for all valid combinations of the attributes and a getter/setter for each.
Two static members converts the attributes to_ and from_xml.

see [MSDN: ExtendedProperty](https://msdn.microsoft.com/en-us/library/office/aa566405(v=exchg.150).aspx)
see [MSDN: ExtendedFieldURI] (https://msdn.microsoft.com/en-us/library/office/aa564843(v=exchg.150).aspx)

This commit will fix issue #7 
