### PR TITLE
GCC: more pedantic warning level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,11 +80,11 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
         set(CMAKE_CXX_FLAGS
             "${CMAKE_CXX_FLAGS} -std=${CXX_STANDARD_TAG}")
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
+    # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-qual -Wcast-align -Wdisabled-optimization -Wformat=2 -Wlogical-op -Wmissing-include-dirs -Wshadow -Wredundant-decls")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
-    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
-    endif()
 
     # Use colorized output on terminal if supported (GCC 4.9 onwards)
     CHECK_CXX_COMPILER_FLAG("-fdiagnostics-color=auto" GCC_HAS_COLOR)

--- a/include/ews/rapidxml/rapidxml.hpp
+++ b/include/ews/rapidxml/rapidxml.hpp
@@ -86,8 +86,8 @@ namespace rapidxml
 
     public:
         //! Constructs parse error
-        parse_error(const char* what, void* where)
-            : m_what(what), m_where(where)
+        parse_error(const char* what_, void* where_)
+            : m_what(what_), m_where(where_)
         {
         }
 


### PR DESCRIPTION
Added -Wpedantic and some more warning flags to GCC's command line