### PR TITLE
Increase clang warning level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     # In what sane world does 'extra' mean more than 'all', and 'all' and
     # 'everything' mean different things?
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything -fcolor-diagnostics")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -Wno-c++98-compat -Wno-covered-switch-default -Wno-switch-enum -Wno-weak-vtables -Wno-exit-time-destructors -Wno-global-constructors -Wno-padded")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -Wno-c++98-compat -Wno-covered-switch-default -Wno-switch-enum -Wno-weak-vtables -Wno-exit-time-destructors -Wno-global-constructors -Wno-padded -Wno-conversion -Wno-sign-conversion -Wno-c++98-compat-pedantic -Wno-disabled-macro-expansion -Wno-undef")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     patch_cmake_cxx_debug_flags()
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS GNUCXX_MINIMUM_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,11 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     if(ENABLE_LIBCXX)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+
+    # In what sane world does 'extra' mean more than 'all', and 'all' and
+    # 'everything' mean different things?
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything -fcolor-diagnostics")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -Wno-c++98-compat -Wno-covered-switch-default -Wno-switch-enum -Wno-weak-vtables -Wno-exit-time-destructors -Wno-global-constructors -Wno-padded")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     patch_cmake_cxx_debug_flags()
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS GNUCXX_MINIMUM_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,6 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     endif()
 
-    # In what sane world does 'extra' mean more than 'all', and 'all' and
-    # 'everything' mean different things?
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything -fcolor-diagnostics")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -Wno-c++98-compat -Wno-covered-switch-default -Wno-switch-enum -Wno-weak-vtables -Wno-exit-time-destructors -Wno-global-constructors -Wno-padded -Wno-conversion -Wno-sign-conversion -Wno-c++98-compat-pedantic -Wno-disabled-macro-expansion -Wno-undef")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -4711,6 +4711,7 @@ namespace ews
         public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
             virtual ~credentials() = default;
+            credentials& operator=(const credentials&) = default;
 #else
             virtual ~credentials() {}
 #endif

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -4013,7 +4013,7 @@ namespace ews
         people_connect,
 
         //! Represents the Favorites folder
-        favorites,
+        favorites
     };
 
     //! \brief Indicates whether a user is interested in the internal or
@@ -5724,6 +5724,7 @@ namespace ews
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
         folder_id() = default;
         virtual ~folder_id() = default;
+        folder_id(const folder_id&) = default;
 #else
         folder_id() {}
         virtual ~folder_id() {}
@@ -8147,7 +8148,7 @@ namespace ews
         nov,
 
         //! December
-        dec,
+        dec
     };
 
     namespace internal
@@ -11595,7 +11596,6 @@ namespace ews
     public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
         search_expression() = delete;
-        ~search_expression() = default;
 #endif
 
         std::string to_xml() const { return func_(); }

--- a/include/ews/rapidxml/rapidxml.hpp
+++ b/include/ews/rapidxml/rapidxml.hpp
@@ -91,9 +91,19 @@ namespace rapidxml
         {
         }
 
+        // TODO make what() noexcept
+#if defined(__clang__) || defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+
         //! Gets human readable description of error.
         //! \return Pointer to null terminated description of the error.
         virtual const char* what() const throw() { return m_what; }
+
+#if defined(__clang__) || defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
         //! Gets pointer to character data where error happened.
         //! Ch should be the same as char type of xml_document that produced

--- a/include/ews/rapidxml/rapidxml.hpp
+++ b/include/ews/rapidxml/rapidxml.hpp
@@ -392,7 +392,6 @@ namespace rapidxml
     ///////////////////////////////////////////////////////////////////////
     // Internals
 
-    //! \cond internal
     namespace internal
     {
 
@@ -703,12 +702,11 @@ namespace rapidxml
     //! <code>RAPIDXML_ALIGNMENT</code>
     //! to obtain best wasted memory to performance compromise.
     //! To do it, define their values before rapidxml.hpp file is included.
-    //! \param Ch Character type of created nodes.
+    //! \tparam Ch Character type of created nodes.
     template <class Ch = char> class memory_pool
     {
 
     public:
-        //! \cond internal
         typedef void*(alloc_func)(std::size_t); // Type of user-defined function
                                                 // used to allocate memory
         typedef void(free_func)(void*); // Type of user-defined function used to
@@ -1017,7 +1015,7 @@ namespace rapidxml
 
     //! Base class for xml_node and xml_attribute implementing common functions:
     //! name(), name_size(), value(), value_size() and parent().
-    //! \param Ch Character type to use
+    //! \tparam Ch Character type to use
     template <class Ch = char> class xml_base
     {
     public:
@@ -1283,7 +1281,7 @@ namespace rapidxml
     //! Note that after parse, both name and value of attribute will point to
     //! interior of source text used for parsing.
     //! Thus, this text must persist in memory for the lifetime of attribute.
-    //! \param Ch Character type to use.
+    //! \tparam Ch Character type to use.
     template <class Ch = char> class xml_attribute : public xml_base<Ch>
     {
 
@@ -1435,7 +1433,7 @@ namespace rapidxml
     //! Note that after parse, both name and value of node, if any, will point
     //! interior of source text used for parsing.
     //! Thus, this text must persist in the memory for the lifetime of node.
-    //! \param Ch Character type to use.
+    //! \tparam Ch Character type to use.
     template <class Ch = char> class xml_node : public xml_base<Ch>
     {
     public:
@@ -2149,7 +2147,7 @@ namespace rapidxml
     //! which are inherited from memory_pool.
     //! To access root node of the document, use the document itself, as if it
     //! was an xml_node.
-    //! \param Ch Character type to use.
+    //! \tparam Ch Character type to use.
     template <class Ch = char>
     class xml_document : public xml_node<Ch>, public memory_pool<Ch>
     {

--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -27,7 +27,6 @@
 #include <ews/ews.hpp>
 #include <ews/ews_test_support.hpp>
 #include <ews/rapidxml/rapidxml.hpp>
-#include <gtest/gtest.h>
 
 #ifdef EWS_USE_BOOST_LIBRARY
 #include <boost/filesystem.hpp>
@@ -35,6 +34,8 @@
 #include <iostream>
 #include <iterator>
 #endif
+
+#include "gtest-wrapper.hpp"
 
 namespace tests
 {

--- a/tests/gtest-wrapper.hpp
+++ b/tests/gtest-wrapper.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-noreturn"
+#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
+#pragma GCC diagnostic ignored "-Wshift-sign-overflow"
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+
+#include <gtest/gtest.h>
+
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+// vim:et ts=4 sw=4 noic cc=80

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -16,7 +16,6 @@
 //   This project is hosted at https://github.com/otris
 
 #include <ews/ews_test_support.hpp>
-#include <gtest/gtest.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -34,6 +33,8 @@
 #include <limits.h>
 #include <unistd.h>
 #endif
+
+#include "gtest-wrapper.hpp"
 
 typedef std::unordered_map<std::string, std::string> argument_map;
 

--- a/tests/test_internals.cpp
+++ b/tests/test_internals.cpp
@@ -19,11 +19,12 @@
 #include <cstring>
 #include <ews/ews.hpp>
 #include <ews/rapidxml/rapidxml_print.hpp>
-#include <gtest/gtest.h>
 #include <iterator>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include "gtest-wrapper.hpp"
 
 namespace
 {


### PR DESCRIPTION
This PR increases Clang's warning-level significantly.

We already have GCC with pedantic in master. Merging this branch makes clang++ more nitpicking, too.

Changes:
- switch warning level from -Wall to -Weverything and turn off unneeded or unwanted warnings explicitly
- turn on color in diagnostics explicitly as terminal detection does not always seem to work
- wrap <gtest/gtest.h> in new header file, switch off some noisy warnings from Google Test framework
- and last but not least, fix some harmless warnings in rapidxml.hpp and ews.hpp