### PR TITLE
Make update_item support set, append, and delete

### DIFF
--- a/include/ews/ews_fwd.hpp
+++ b/include/ews/ews_fwd.hpp
@@ -65,6 +65,7 @@ namespace ews
     class search_expression;
     class soap_fault;
     class task;
+    class update;
     enum class autodiscover_protocol;
     template <typename T> class basic_service;
     bool operator==(const date_time&, const date_time&);

--- a/tests/test_service.cpp
+++ b/tests/test_service.cpp
@@ -268,7 +268,9 @@ namespace tests
         additional_recipients.push_back(ews::mailbox("gus.goose@duckburg.com"));
         auto prop = ews::property(ews::message_property_path::to_recipients,
                                   additional_recipients);
-        auto new_id = service().update_item(message.get_item_id(), prop);
+        auto change = ews::update(prop,
+                                  ews::update::operation::append_to_item_field);
+        auto new_id = service().update_item(message.get_item_id(), change);
         message = service().get_message(item_id);
         ASSERT_EQ(2U, message.get_to_recipients().size());
     }


### PR DESCRIPTION
Introduce `ews::update` class. `update` class renders a single
<SetItemField>, <AppendToItemField>, or <DeleteItemField> operation. The
constructor of update is a converting c'tor which renders a
<SetItemField> of a given property by default.

Introduce an update_item overload set:

 - item_id update_item(item_id, update, ...) and
 - item_id update_item(item_id const std::vector<update>&, ...)

Fixes issue #16