### PR TITLE
Add Travis & AppVeyor build support and badges

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,25 @@
+version: '{branch}#{build}'
+image: Visual Studio 2013
+clone_folder: c:/projects/ews-cpp-64-12
+install:
+- cmd: git submodule update --init --recursive
+build_script:
+- cmd: >-
+    cd C:\projects\ews-cpp-64-12\scripts
+
+    sed -e s/14/12/g build-curl.bat > build.bat
+
+    set ERRORLEVEL=0
+
+    build.bat
+
+    set ERRORLEVEL=""
+
+    cd ..
+
+    cmake -Bbuild -H. -G "Visual Studio 12 2013 Win64" -DCURL_LIBRARY="C:\projects\ews-cpp-64-12\scripts\win64-debug\lib\libcurl_debug.lib" -DCURL_INCLUDE_DIR="C:\projects\ews-cpp-64-12\scripts\win64-debug\include"
+
+
+    cd build
+
+    cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+# ews-cpp travis build
+
+os:
+    - linux 
+
+language: cpp
+
+sudo: required
+
+dist: trusty
+
+cache: apt
+
+compiler:  
+    - gcc
+    - clang
+
+before_install:
+#   - sudo add-apt-repository ppa:george-edison55/cmake-3.x --yes
+#   - sudo apt-get update
+#   - sudo apt-get remove clang llvm-dev
+install:
+#    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+    - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8" && export CC="clang-3.8"; fi 
+addons:
+  apt:
+    sources:
+#    - ubuntu-toolchain-r-test
+#    - llvm-toolchain-precise-3.8
+#    - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
+    packages:
+#    - gcc-4.8
+#    - g++-4.8
+#- clang
+    - clang-3.8
+    - llvm-3.8-dev
+    - libstdc++6
+#    - cmake
+#    - cmake-data
+#- libcurl4-openssl-dev
+    - libcurl4-gnutls-dev
+
+before_script:
+#    - export CFLAGS=-m64
+    - cmake -H. -Bbuild_gcc -DCMAKE_BUILD_TYPE=Release -G"Unix Makefiles"
+    - cmake -H. -Bbuild_clang -DENABLE_LIBCXX:BOOLEAN=ON -DCMAKE_BUILD_TYPE=Release -G"Unix Makefiles"
+#    - export CFLAGS=-m32
+#    - cmake -H. -Bbuild_gcc_32 -DCMAKE_BUILD_TYPE=Release -G"Unix Makefiles"
+#    - cmake -H. -Bbuild_clang_32 -DENABLE_LIBCXX:BOOLEAN=true -DCMAKE_BUILD_TYPE=Release -G"Unix Makefiles"
+
+script: 
+    - if [ "$CXX" = "g++" ]; then cmake --build build_gcc; fi
+    - if ! [ "$CXX" = "g++" ]; then cmake --build build_clang; fi
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ C++ application.
     - with libstdc++ on Linux (Note that we don't support libc++ on Linux)
 * GCC since 4.8 with libstdc++
 
+|Compiler|64 bit|32 bit|
+|--------|:----:|:----:|
+|Visual Studio 2012| - | - |
+|Visual Studio 2013|[![Build status](https://ci.appveyor.com/api/projects/status/6t0hsgh540vmml9c/branch/master?svg=true)](https://ci.appveyor.com/project/raldus/ews-cpp-ea5m3/branch/master)|[![Build status](https://ci.appveyor.com/api/projects/status/mv0vp5nujv3nj3kx/branch/master?svg=true)](https://ci.appveyor.com/project/raldus/ews-cpp-yxo80/branch/master)|
+|Visual Studio 2015|[![Build status](https://ci.appveyor.com/api/projects/status/h0pt39gcb97wrfys/branch/master?svg=true)](https://ci.appveyor.com/project/raldus/ews-cpp-do8dr/branch/master)|[![Build status](https://ci.appveyor.com/api/projects/status/dl2vrfa5c7wdprrf/branch/master?svg=true)](https://ci.appveyor.com/project/raldus/ews-cpp-pa626/branch/master)|
+|Clang 3.5 with libc++|[![Build Status](https://travis-ci.org/otris/ews-cpp.svg?branch=master)](https://travis-ci.org/otris/ews-cpp)| - |
+|GCC 4.8 with libstdc++|[![Build Status](https://travis-ci.org/otris/ews-cpp.svg?branch=master)](https://travis-ci.org/otris/ews-cpp)| - |
+
 
 ## Supported Operating Systems
 


### PR DESCRIPTION
Add  continuous integration with [AppVeyour](https://ci.appveyor.com) on Windows and [Travis](https://travis-ci.org) on Linux/OSX.

The files .appveyor.yml and .travis.yml are new and README.md is showing status badges of that builds. 
Everything works fine except of all tests and compiling with clang-3.5 on Travis.

This will fix issue "Add public CI" #25.