### PR TITLE
Make autodiscover great again

### DIFF
--- a/examples/autodiscover.cpp
+++ b/examples/autodiscover.cpp
@@ -16,11 +16,11 @@
 #include <ews/ews.hpp>
 #include <ews/ews_test_support.hpp>
 
-#include <string>
+#include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <ostream>
-#include <exception>
-#include <cstdlib>
+#include <string>
 
 using ews::internal::http_request;
 
@@ -35,12 +35,11 @@ int main()
         ews::basic_credentials credentials(env.autodiscover_smtp_address,
                                            env.autodiscover_password);
         ews::autodiscover_hints hints;
-        hints.autodiscover_url = "https://exch.otris.de/autodiscover/autodiscover.xml";
+        hints.autodiscover_url =
+            "https://exch.otris.de/autodiscover/autodiscover.xml";
 
-        auto result =
-            ews::get_exchange_web_services_url<http_request>(
-                                    env.autodiscover_smtp_address,
-                                    credentials, hints);
+        auto result = ews::get_exchange_web_services_url<http_request>(
+            env.autodiscover_smtp_address, credentials, hints);
 
         std::cout << result.internal_ews_url << std::endl;
         std::cout << result.external_ews_url << std::endl;

--- a/examples/autodiscover.cpp
+++ b/examples/autodiscover.cpp
@@ -34,14 +34,16 @@ int main()
         const auto env = ews::test::environment();
         ews::basic_credentials credentials(env.autodiscover_smtp_address,
                                            env.autodiscover_password);
+        ews::autodiscover_hints hints;
+        hints.autodiscover_url = "https://exch.otris.de/autodiscover/autodiscover.xml";
 
-        auto ews_url =
+        auto result =
             ews::get_exchange_web_services_url<http_request>(
                                     env.autodiscover_smtp_address,
-                                    ews::autodiscover_protocol::internal,
-                                    credentials);
+                                    credentials, hints);
 
-        std::cout << ews_url << std::endl;
+        std::cout << result.internal_ews_url << std::endl;
+        std::cout << result.external_ews_url << std::endl;
     }
     catch (std::exception& exc)
     {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -5267,9 +5267,11 @@ namespace internal
 #else
     template <typename RequestHandler>
 #endif
-    inline autodiscover_result get_exchange_web_services_url(
-        const std::string& user_smtp_address, const basic_credentials& credentials, unsigned int redirections,
-        const autodiscover_hints& hints)
+    inline autodiscover_result
+    get_exchange_web_services_url(const std::string& user_smtp_address,
+                                  const basic_credentials& credentials,
+                                  unsigned int redirections,
+                                  const autodiscover_hints& hints)
     {
         autodiscover_result result;
         using rapidxml::internal::compare;
@@ -5303,7 +5305,7 @@ namespace internal
         // passphrase in plain-text
         auto autodiscover_url =
             "https://" + domain + "/autodiscover/autodiscover.xml";
-        if(hints.autodiscover_url.size() != 0)
+        if (hints.autodiscover_url.size() != 0)
         {
             autodiscover_url = hints.autodiscover_url;
         }
@@ -5385,7 +5387,7 @@ namespace internal
         // protocol type (internal/external) and then look for the
         // corresponding <ASUrl/> element
         std::string protocol;
-        for(int i = 0; i < 2; i++)
+        for (int i = 0; i < 2; i++)
         {
             for (auto protocol_node = account_node->first_node(); protocol_node;
                  protocol_node = protocol_node->next_sibling())
@@ -5402,31 +5404,36 @@ namespace internal
                             protocol_node->local_name_size(), "Protocol",
                             std::strlen("Protocol")))
                 {
-                    for (auto type_node = protocol_node->first_node(); type_node;
-                         type_node = type_node->next_sibling())
+                    for (auto type_node = protocol_node->first_node();
+                         type_node; type_node = type_node->next_sibling())
                     {
                         if (compare(type_node->local_name(),
                                     type_node->local_name_size(), "Type",
                                     std::strlen("Type")) &&
                             compare(type_node->value(), type_node->value_size(),
-                                    protocol.c_str(), std::strlen(protocol.c_str())))
+                                    protocol.c_str(),
+                                    std::strlen(protocol.c_str())))
                         {
                             for (auto asurl_node = protocol_node->first_node();
                                  asurl_node;
                                  asurl_node = asurl_node->next_sibling())
                             {
                                 if (compare(asurl_node->local_name(),
-                                            asurl_node->local_name_size(), "ASUrl",
-                                            std::strlen("ASUrl")))
+                                            asurl_node->local_name_size(),
+                                            "ASUrl", std::strlen("ASUrl")))
                                 {
-                                    if(i >= 1)
+                                    if (i >= 1)
                                     {
-                                        result.internal_ews_url = std::string(asurl_node->value(), asurl_node->value_size());
+                                        result.internal_ews_url = std::string(
+                                            asurl_node->value(),
+                                            asurl_node->value_size());
                                         return result;
                                     }
                                     else
                                     {
-                                        result.external_ews_url = std::string(asurl_node->value(), asurl_node->value_size());
+                                        result.external_ews_url = std::string(
+                                            asurl_node->value(),
+                                            asurl_node->value_size());
                                     }
                                 }
                             }
@@ -5502,7 +5509,8 @@ template <typename RequestHandler>
 #endif
 inline autodiscover_result
 get_exchange_web_services_url(const std::string& user_smtp_address,
-                              const basic_credentials& credentials, const autodiscover_hints& hints)
+                              const basic_credentials& credentials,
+                              const autodiscover_hints& hints)
 {
     return internal::get_exchange_web_services_url<RequestHandler>(
         user_smtp_address, credentials, 0U, hints);
@@ -9483,8 +9491,8 @@ public:
         other
     };
 
-    physical_address(key k, std::string street,
-                     std::string city, std::string state, std::string cor,
+    physical_address(key k, std::string street, std::string city,
+                     std::string state, std::string cor,
                      std::string postal_code)
         : key_(std::move(k)), street_(std::move(street)),
           city_(std::move(city)), state_(std::move(state)),
@@ -9527,7 +9535,8 @@ inline bool operator==(const physical_address& lhs, const physical_address& rhs)
 
 namespace internal
 {
-    inline physical_address::key string_to_physical_address_key(const std::string& keystring)
+    inline physical_address::key
+    string_to_physical_address_key(const std::string& keystring)
     {
         physical_address::key k;
         if (keystring == "Home")
@@ -12466,10 +12475,7 @@ class property_path
 {
 public:
     // Intentionally not explicit
-    property_path(const char* uri) : uri_(uri)
-    {
-        class_name();
-    }
+    property_path(const char* uri) : uri_(uri) { class_name(); }
 
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
     virtual ~property_path() = default;

--- a/include/ews/ews_fwd.hpp
+++ b/include/ews/ews_fwd.hpp
@@ -66,16 +66,20 @@ class search_expression;
 class soap_fault;
 class task;
 class update;
-enum class autodiscover_protocol;
+struct autodiscover_result;
+struct autodiscover_hints;
 template <typename T> class basic_service;
 bool operator==(const date_time&, const date_time&);
 bool operator==(const property_path&, const property_path&);
 void set_up() EWS_NOEXCEPT;
 void tear_down() EWS_NOEXCEPT;
 template <typename T>
-std::string get_exchange_web_services_url(const std::string&,
-                                          autodiscover_protocol,
-                                          const basic_credentials&);
+autodiscover_result get_exchange_web_services_url(const std::string&,
+                                        const basic_credentials&);
+template <typename T>
+autodiscover_result get_exchange_web_services_url(const std::string&,
+                                        const basic_credentials&,
+                                        const autodiscover_hints&);
 }
 
 // vim:et ts=4 sw=4

--- a/include/ews/ews_fwd.hpp
+++ b/include/ews/ews_fwd.hpp
@@ -75,11 +75,8 @@ void set_up() EWS_NOEXCEPT;
 void tear_down() EWS_NOEXCEPT;
 template <typename T>
 autodiscover_result get_exchange_web_services_url(const std::string&,
-                                        const basic_credentials&);
-template <typename T>
-autodiscover_result get_exchange_web_services_url(const std::string&,
-                                        const basic_credentials&,
-                                        const autodiscover_hints&);
+                                                  const basic_credentials&,
+                                                  const autodiscover_hints&);
 }
 
 // vim:et ts=4 sw=4

--- a/tests/test_autodiscover.cpp
+++ b/tests/test_autodiscover.cpp
@@ -64,7 +64,7 @@ TEST_F(AutodiscoverTest, EmptyAddressThrows)
     EXPECT_THROW(
         {
             auto result = ews::get_exchange_web_services_url<http_request_mock>(
-                "", ews::autodiscover_protocol::internal, credentials());
+                "", credentials());
         },
         ews::exception);
 }
@@ -77,7 +77,7 @@ TEST_F(AutodiscoverTest, EmptyAddressExceptionText)
     try
     {
         auto result = ews::get_exchange_web_services_url<http_request_mock>(
-            "", ews::autodiscover_protocol::internal, credentials());
+            "", credentials());
         FAIL() << "Expected an exception";
     }
     catch (ews::exception& exc)
@@ -94,7 +94,7 @@ TEST_F(AutodiscoverTest, InvalidAddressThrows)
     EXPECT_THROW(
         {
             auto result = ews::get_exchange_web_services_url<http_request_mock>(
-                "typo", ews::autodiscover_protocol::internal, credentials());
+                "typo", credentials());
         },
         ews::exception);
 }
@@ -107,7 +107,7 @@ TEST_F(AutodiscoverTest, InvalidAddressExceptionText)
     try
     {
         auto result = ews::get_exchange_web_services_url<http_request_mock>(
-            "typo", ews::autodiscover_protocol::internal, credentials());
+            "typo", credentials());
         FAIL() << "Expected an exception";
     }
     catch (ews::exception& exc)
@@ -123,15 +123,32 @@ TEST_F(AutodiscoverTest, GetExchangeWebServicesURL)
 
     // Internal should return ASUrl element's value in EXCH protocol
     auto result = ews::get_exchange_web_services_url<http_request_mock>(
-        address(), ews::autodiscover_protocol::internal, credentials());
+        address(), credentials());
     EXPECT_STREQ("https://outlook.office365.com/EWS/Exchange.asmx",
-                 result.c_str());
+                 result.internal_ews_url.c_str());
 
     // External should return ASUrl element's value in EXPR protocol
-    result = ews::get_exchange_web_services_url<http_request_mock>(
-        address(), ews::autodiscover_protocol::external, credentials());
     EXPECT_STREQ("https://outlook.another.office365.com/EWS/Exchange.asmx",
-                 result.c_str());
+                 result.external_ews_url.c_str());
+}
+
+TEST_F(AutodiscoverTest, GetExchangeWebServicesURLWithHint)
+{
+    auto& s = http_request_mock::storage::instance();
+    ews::autodiscover_hints hints;
+    hints.autodiscover_url =
+        "https://some.domain.com/autodiscover/autodiscover.xml";
+    auto result = ews::get_exchange_web_services_url<http_request_mock>(
+        address(), credentials(), hints);
+    EXPECT_STREQ("<?xml version=\"1.0\" encoding=\"utf-8\" ?><Autodiscover "
+                 "xmlns=\"http://schemas.microsoft.com/exchange/autodiscover/"
+                 "outlook/requestschema/"
+                 "2006\"><Request><EMailAddress>dduck@duckburg.onmicrosoft.com<"
+                 "/EMailAddress><AcceptableResponseSchema>http://"
+                 "schemas.microsoft.com/exchange/autodiscover/outlook/"
+                 "responseschema/2006a</AcceptableResponseSchema></Request></"
+                 "Autodiscover>",
+                 s.request_string.c_str());
 }
 
 TEST_F(AutodiscoverTest, GetExchangeWebServicesURLThrowsOnError)
@@ -146,7 +163,7 @@ TEST_F(AutodiscoverTest, GetExchangeWebServicesURLThrowsOnError)
     EXPECT_THROW(
         {
             ews::get_exchange_web_services_url<http_request_mock>(
-                address(), ews::autodiscover_protocol::internal, credentials());
+                address(), credentials());
         },
         ews::exception);
 }
@@ -158,8 +175,8 @@ TEST_F(AutodiscoverTest, GetExchangeWebServicesURLExceptionText)
 
     try
     {
-        ews::get_exchange_web_services_url<http_request_mock>(
-            address(), ews::autodiscover_protocol::internal, credentials());
+        ews::get_exchange_web_services_url<http_request_mock>(address(),
+                                                              credentials());
         FAIL() << "Expected an exception";
     }
     catch (ews::exception& exc)


### PR DESCRIPTION
This pr removes the unneeded autodiscover_protocol type and implements autodiscover_result and autodiscover_hints, which are now both implemented in the get_exchange_web_services_url functions.
The function now has an overload, so the autodiscover_hints parameter is optional.  
The tests and the autodiscover.cpp example have also been adjusted.