### PR TITLE
Make autodiscover great again -- The second coming

### DIFF
--- a/examples/autodiscover.cpp
+++ b/examples/autodiscover.cpp
@@ -16,11 +16,11 @@
 #include <ews/ews.hpp>
 #include <ews/ews_test_support.hpp>
 
-#include <string>
+#include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <ostream>
-#include <exception>
-#include <cstdlib>
+#include <string>
 
 using ews::internal::http_request;
 
@@ -34,14 +34,15 @@ int main()
         const auto env = ews::test::environment();
         ews::basic_credentials credentials(env.autodiscover_smtp_address,
                                            env.autodiscover_password);
+        ews::autodiscover_hints hints;
+        hints.autodiscover_url =
+            "https://exch.otris.de/autodiscover/autodiscover.xml";
 
-        auto ews_url =
-            ews::get_exchange_web_services_url<http_request>(
-                                    env.autodiscover_smtp_address,
-                                    ews::autodiscover_protocol::internal,
-                                    credentials);
+        auto result = ews::get_exchange_web_services_url<http_request>(
+            env.autodiscover_smtp_address, credentials, hints);
 
-        std::cout << ews_url << std::endl;
+        std::cout << result.internal_ews_url << std::endl;
+        std::cout << result.external_ews_url << std::endl;
     }
     catch (std::exception& exc)
     {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -5273,8 +5273,6 @@ namespace internal
                                   unsigned int redirections,
                                   const autodiscover_hints& hints)
     {
-        autodiscover_result result;
-        std::string autodiscover_url;
         using rapidxml::internal::compare;
 
         // Check redirection counter. We don't want to get in an endless
@@ -5290,6 +5288,7 @@ namespace internal
             throw exception("Empty SMTP address given");
         }
 
+        std::string autodiscover_url;
         if (hints.autodiscover_url.empty())
         {
             // Get user name and domain part from the SMTP address
@@ -5391,6 +5390,7 @@ namespace internal
         // protocol type (internal/external) and then look for the
         // corresponding <ASUrl/> element
         std::string protocol;
+        autodiscover_result result;
         for (int i = 0; i < 2; i++)
         {
             for (auto protocol_node = account_node->first_node(); protocol_node;

--- a/include/ews/ews_fwd.hpp
+++ b/include/ews/ews_fwd.hpp
@@ -66,16 +66,20 @@ class search_expression;
 class soap_fault;
 class task;
 class update;
-enum class autodiscover_protocol;
+struct autodiscover_result;
+struct autodiscover_hints;
 template <typename T> class basic_service;
 bool operator==(const date_time&, const date_time&);
 bool operator==(const property_path&, const property_path&);
 void set_up() EWS_NOEXCEPT;
 void tear_down() EWS_NOEXCEPT;
 template <typename T>
-std::string get_exchange_web_services_url(const std::string&,
-                                          autodiscover_protocol,
-                                          const basic_credentials&);
+autodiscover_result get_exchange_web_services_url(const std::string&,
+                                                  const basic_credentials&);
+template <typename T>
+autodiscover_result get_exchange_web_services_url(const std::string&,
+                                                  const basic_credentials&,
+                                                  const autodiscover_hints&);
 }
 
 // vim:et ts=4 sw=4

--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -97,6 +97,7 @@ struct http_request_mock final
 
         std::string request_string;
         std::vector<char> fake_response;
+        std::string url;
     };
 
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -120,7 +121,11 @@ struct http_request_mock final
         POST
     };
 
-    explicit http_request_mock(const std::string&) {}
+    explicit http_request_mock(const std::string& url)
+    {
+        auto& s = storage::instance();
+        s.url = url;
+    }
 
     void set_method(method) {}
 


### PR DESCRIPTION
This pr removes the unneeded autodiscover_protocol type and implements autodiscover_result and autodiscover_hints, which are now both implemented in the get_exchange_web_services_url functions.
The function now has an overload, so the autodiscover_hints parameter is optional.
The tests and the autodiscover.cpp example have also been adjusted.