### PR TITLE
Add send_item bulk operation overloads

### DIFF
--- a/tests/test_items.cpp
+++ b/tests/test_items.cpp
@@ -983,6 +983,57 @@ TEST_F(ItemTest, CreateItemsWithEmptyVector)
     }
     FAIL();
 }
+
+TEST_F(ItemTest, SendItemsWithVector)
+{
+    std::vector<ews::message> messages;
+    auto message = ews::message();
+    std::vector<ews::mailbox> recipients;
+    for (int i = 0; i < 10; i++)
+    {
+        message.set_subject("?");
+        recipients.push_back(ews::mailbox("whoishere@home.com"));
+        message.set_to_recipients(recipients);
+        messages.push_back(message);
+    }
+
+    auto message_ids =
+        service().create_item(messages, ews::message_disposition::save_only);
+    ews::internal::on_scope_exit remove_messages([&] {
+        for (auto& id : message_ids)
+        {
+            service().delete_item(id);
+        }
+    });
+
+    EXPECT_NO_THROW(service().send_item(message_ids));
+}
+
+TEST_F(ItemTest, SendItemsWithEmptyVector)
+{
+    std::vector<ews::message> messages;
+    auto message = ews::message();
+    std::vector<ews::mailbox> recipients;
+    for (int i = 0; i < 10; i++)
+    {
+        message.set_subject("?");
+        recipients.push_back(ews::mailbox("whoishere@home.com"));
+        message.set_to_recipients(recipients);
+        messages.push_back(message);
+    }
+
+    auto message_ids =
+        service().create_item(messages, ews::message_disposition::save_only);
+    ews::internal::on_scope_exit remove_messages([&] {
+        for (auto& id : message_ids)
+        {
+            service().delete_item(id);
+        }
+    });
+    message_ids.clear();
+
+    EXPECT_THROW(service().send_item(message_ids), ews::exception);
+}
 }
 
 // vim:et ts=4 sw=4

--- a/tests/test_items.cpp
+++ b/tests/test_items.cpp
@@ -1011,28 +1011,8 @@ TEST_F(ItemTest, SendItemsWithVector)
 
 TEST_F(ItemTest, SendItemsWithEmptyVector)
 {
-    std::vector<ews::message> messages;
-    auto message = ews::message();
-    std::vector<ews::mailbox> recipients;
-    for (int i = 0; i < 10; i++)
-    {
-        message.set_subject("?");
-        recipients.push_back(ews::mailbox("whoishere@home.com"));
-        message.set_to_recipients(recipients);
-        messages.push_back(message);
-    }
-
-    auto message_ids =
-        service().create_item(messages, ews::message_disposition::save_only);
-    ews::internal::on_scope_exit remove_messages([&] {
-        for (auto& id : message_ids)
-        {
-            service().delete_item(id);
-        }
-    });
-    message_ids.clear();
-
-    EXPECT_THROW(service().send_item(message_ids), ews::exception);
+    std::vector<ews::item_id> ids;
+    EXPECT_THROW(service().send_item(ids), ews::exception);
 }
 }
 


### PR DESCRIPTION
The send_item functions can now be used with `std::vector<item_id>` which is needed for sending multiple messages at once.