### PR TITLE
Autodeploy Doxygen docs to GH pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 ---
-addons:
-  apt:
-    packages:
-      - libcurl4-gnutls-dev
 before_script:
-  - "cmake -H. -Bbuild_gcc -DCMAKE_BUILD_TYPE=Release -G\"Unix Makefiles\""
+  - "sudo apt-get install libcurl4-gnutls-dev"
+  - "mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .."
 cache: apt
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 ---
+branches:
+  only:
+    - master
 before_script:
-  - "sudo apt-get install libcurl4-gnutls-dev"
+  - "sudo apt-get install doxygen graphviz libcurl4-gnutls-dev"
   - "mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .."
 cache: apt
 compiler:
@@ -10,6 +13,12 @@ language: cpp
 os:
   - linux
 script:
-  - "if [ \"$CXX\" = \"g++\" ]; then cmake --build build_gcc; fi"
+  - "make && make doc"
 sudo: required
-
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: $TRAVIS_BUILD_DIR/build/html
+  github_token: $GH_REPO_TOKEN
+  on:
+    branch: master


### PR DESCRIPTION
The docs are now automatically created and pushed to gh-pages, the only step still needed for this repository is creating said branch:
https://gist.github.com/vidavidorra/548ffbcdae99d752da02#create-a-clean-gh-pages-branch

In total:
- The .travis.yml has been cleaned up
- The .travis.yml has been adjusted to autodeploy

The output of said deployment can be seen [here](https://github.com/m-Schlitzer/ews-cpp/tree/gh-pages). This pull request closes #67 .