### PR TITLE
Add <ResolveNames> operation and example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ add_example(get_meeting_room_calendar)
 add_example(office365)
 add_example(raw_soap_request)
 add_example(remove_delegate)
+add_example(resolve_names)
 add_example(send_message)
 add_example(update_contact)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ add_executable(tests
     tests/test_internals.cpp
     tests/test_items.cpp
     tests/test_messages.cpp
+    tests/test_resolve_names.cpp
     tests/test_restrictions.cpp
     tests/test_service.cpp
     tests/test_tasks.cpp

--- a/examples/resolve_names.cpp
+++ b/examples/resolve_names.cpp
@@ -33,11 +33,8 @@ int main()
                                     env.password);
 
         std::string name = "person";
-        std::vector<ews::folder_id> id_vector;
-        ews::folder_id folder;
-        id_vector.push_back(folder);
-        auto response = service.resolve_names(
-            name, ews::search_scope::active_directory, id_vector);
+        auto response =
+            service.resolve_names(name, ews::search_scope::active_directory);
         std::cout << response.total_items_in_view << std::endl;
         for (auto reso : response.resolutions)
         {

--- a/examples/resolve_names.cpp
+++ b/examples/resolve_names.cpp
@@ -36,7 +36,7 @@ int main()
         auto response =
             service.resolve_names(name, ews::search_scope::active_directory);
         std::cout << response.total_items_in_view << std::endl;
-        for (auto reso : response.resolutions)
+        for (const auto& reso : response.resolutions)
         {
             std::cout << reso.mailbox.name() << std::endl;
             std::cout << reso.mailbox.value() << std::endl;

--- a/examples/resolve_names.cpp
+++ b/examples/resolve_names.cpp
@@ -39,9 +39,8 @@ int main()
         auto response = service.resolve_names(
             name, ews::searchscope::active_directory, id_vector);
         std::cout << response.total_items_in_view << std::endl;
-        if (response.resolutions.size() > 0)
+        for (auto reso : response.resolutions)
         {
-            auto reso = response.resolutions[0];
             std::cout << reso.mailbox.name() << std::endl;
             std::cout << reso.mailbox.value() << std::endl;
             std::cout << reso.directory_id.id << std::endl;

--- a/examples/resolve_names.cpp
+++ b/examples/resolve_names.cpp
@@ -40,7 +40,7 @@ int main()
         {
             std::cout << reso.mailbox.name() << std::endl;
             std::cout << reso.mailbox.value() << std::endl;
-            std::cout << reso.directory_id.id << std::endl;
+            std::cout << reso.directory_id.get_id() << std::endl;
         }
 
     }

--- a/examples/resolve_names.cpp
+++ b/examples/resolve_names.cpp
@@ -37,7 +37,7 @@ int main()
         ews::folder_id folder;
         id_vector.push_back(folder);
         auto response = service.resolve_names(
-            name, ews::searchscope::active_directory, id_vector);
+            name, ews::search_scope::active_directory, id_vector);
         std::cout << response.total_items_in_view << std::endl;
         for (auto reso : response.resolutions)
         {

--- a/examples/resolve_names.cpp
+++ b/examples/resolve_names.cpp
@@ -1,0 +1,61 @@
+//   Copyright 2017 otris software AG
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#include <ews/ews.hpp>
+#include <ews/ews_test_support.hpp>
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <ostream>
+#include <string>
+
+int main()
+{
+    int res = EXIT_SUCCESS;
+    ews::set_up();
+
+    try
+    {
+        const auto env = ews::test::environment();
+        auto service = ews::service(env.server_uri, env.domain, env.username,
+                                    env.password);
+
+        std::string name = "person";
+        std::vector<ews::folder_id> id_vector;
+        ews::folder_id folder;
+        id_vector.push_back(folder);
+        auto response = service.resolve_names(
+            name, ews::searchscope::active_directory, id_vector);
+        std::cout << response.total_items_in_view << std::endl;
+        if (response.resolutions.size() > 0)
+        {
+            auto reso = response.resolutions[0];
+            std::cout << reso.mailbox.name() << std::endl;
+            std::cout << reso.mailbox.value() << std::endl;
+            std::cout << reso.directory_id.id << std::endl;
+        }
+
+    }
+    catch (std::exception& exc)
+    {
+        std::cout << exc.what() << std::endl;
+        res = EXIT_FAILURE;
+    }
+
+    ews::tear_down();
+    return res;
+}
+
+

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8194,9 +8194,9 @@ static_assert(std::is_move_constructible<resolution>::value, "");
 static_assert(std::is_move_assignable<resolution>::value, "");
 #endif
 
-struct resolution_set
+struct resolution_set final
 {
-    explicit resolution_set()
+    resolution_set()
         : includes_last_item_in_range(true), indexed_paging_offset(0),
           numerator_offset(0), absolute_denominator(0), total_items_in_view(0)
     {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8155,6 +8155,8 @@ static_assert(std::is_move_assignable<mailbox>::value, "");
 
 struct directory_id
 {
+    directory_id() {}
+    directory_id(std::string idstring) { id = idstring; }
     std::string id;
 };
 

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8203,11 +8203,27 @@ struct directory_id
     std::string id;
 };
 
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+static_assert(std::is_default_constructible<directory_id>::value, "");
+static_assert(std::is_copy_constructible<directory_id>::value, "");
+static_assert(std::is_copy_assignable<directory_id>::value, "");
+static_assert(std::is_move_constructible<directory_id>::value, "");
+static_assert(std::is_move_assignable<directory_id>::value, "");
+#endif
+
 struct resolution
 {
     ews::mailbox mailbox;
     ews::directory_id directory_id;
 };
+
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+static_assert(std::is_default_constructible<resolution>::value, "");
+static_assert(std::is_copy_constructible<resolution>::value, "");
+static_assert(std::is_copy_assignable<resolution>::value, "");
+static_assert(std::is_move_constructible<resolution>::value, "");
+static_assert(std::is_move_assignable<resolution>::value, "");
+#endif
 
 struct resolution_set
 {
@@ -8218,6 +8234,14 @@ struct resolution_set
     int total_items_in_view;
     std::vector<resolution> resolutions;
 };
+
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+static_assert(std::is_default_constructible<resolution_set>::value, "");
+static_assert(std::is_copy_constructible<resolution_set>::value, "");
+static_assert(std::is_copy_assignable<resolution_set>::value, "");
+static_assert(std::is_move_constructible<resolution_set>::value, "");
+static_assert(std::is_move_assignable<resolution_set>::value, "");
+#endif
 
 //! \brief Identifies a folder.
 //!

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8182,11 +8182,20 @@ static_assert(std::is_move_assignable<resolution>::value, "");
 
 struct resolution_set
 {
-    int indexed_paging_offset = 0;
-    int numerator_offset = 0;
-    int absolute_denominator = 0;
-    bool includes_last_item_in_range = true;
-    int total_items_in_view = 0;
+    resolution_set()
+    {
+        indexed_paging_offset = 0;
+        numerator_offset = 0;
+        absolute_denominator = 0;
+        includes_last_item_in_range = true;
+        total_items_in_view = 0;
+    }
+
+    int indexed_paging_offset;
+    int numerator_offset;
+    int absolute_denominator;
+    bool includes_last_item_in_range;
+    int total_items_in_view;
     std::vector<resolution> resolutions;
 };
 

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -17963,7 +17963,10 @@ public:
     //! \brief The ResolveNames operation resolves ambiguous email addresses and
     //! display names.
     //!
-    //! Returns a resolution_set which contains a vector<resolution>.
+    //! \param unresolved_entry Partial or full name of the user to look for
+    //! \param scope The scope in which to look for the user
+    //!
+    //! Returns a resolution_set which contains a vector of resolutions.
     //! ContactDataShape and ReturnFullContactData are set by default. A
     //! directory_id is returned in place of the contact.
     resolution_set resolve_names(const std::string& unresolved_entry,
@@ -17973,6 +17976,16 @@ public:
                                   contact_data_shape::id_only);
     }
 
+    //! \brief The ResolveNames operation resolves ambiguous email addresses and
+    //! display names.
+    //!
+    //! \param unresolved_entry Partial or full name of the user to look for
+    //! \param scope The scope in which to look for the user
+    //! \param parent_folder_ids Contains the folder_ids where to look
+    //!
+    //! Returns a resolution_set which contains a vector of resolutions.
+    //! ContactDataShape and ReturnFullContactData are set by default. A
+    //! directory_id is returned in place of the contact.
     resolution_set
     resolve_names(const std::string& unresolved_entry, search_scope scope,
                   const std::vector<folder_id>& parent_folder_ids)

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -6221,50 +6221,58 @@ namespace internal
     };
 }
 
-enum class searchscope
+//! Identifies the order and scope for a ResolveNames search.
+enum class search_scope
 {
+    //! Only the Active Directory directory service is searched.
     active_directory,
+    //! Active Directory is searched first, and then the contact folders that
+    //! are specified in the ParentFolderIds property are searched.
     active_directory_contacts,
+    //! Only the contact folders that are identified by the ParentFolderIds
+    //! property are searched.
     contacts,
+    //! Contact folders that are identified by the ParentFolderIds property are
+    //! searched first and then Active Directory is searched.
     contacts_active_directory
 };
 
 namespace internal
 {
-    inline std::string enum_to_str(searchscope s)
+    inline std::string enum_to_str(search_scope s)
     {
         switch (s)
         {
-        case searchscope::active_directory:
+        case search_scope::active_directory:
             return "ActiveDirectory";
-        case searchscope::active_directory_contacts:
+        case search_scope::active_directory_contacts:
             return "ActiveDirectoryContacts";
-        case searchscope::contacts:
+        case search_scope::contacts:
             return "Contacts";
-        case searchscope::contacts_active_directory:
+        case search_scope::contacts_active_directory:
             return "ContactsActiveDirectory";
         default:
             throw exception("Bad enum value");
         }
     }
 
-    inline searchscope str_to_searchscope(const std::string& str)
+    inline search_scope str_to_search_scope(const std::string& str)
     {
         if (str == "ActiveDirectory")
         {
-            return searchscope::active_directory;
+            return search_scope::active_directory;
         }
         else if (str == "ActiveDirectoryContacts")
         {
-            return searchscope::active_directory_contacts;
+            return search_scope::active_directory_contacts;
         }
         else if (str == "Contacts")
         {
-            return searchscope::contacts;
+            return search_scope::contacts;
         }
         else if (str == "ContactsActiveDirectory")
         {
-            return searchscope::contacts_active_directory;
+            return search_scope::contacts_active_directory;
         }
         else
         {
@@ -17931,7 +17939,7 @@ public:
     //! Returns a resolution_set which contains a vector<resolution>.
     //! ContactDataShape and ReturnFullContactData are set by default. A
     //! directory_id is returned in place of the contact.
-    resolution_set resolve_names(const std::string& name, searchscope scope,
+    resolution_set resolve_names(const std::string& name, search_scope scope,
                                  std::vector<folder_id> parent_folder_ids = {})
     {
         return resolve_names_impl(name, parent_folder_ids, true, scope,
@@ -18528,7 +18536,7 @@ private:
     resolution_set resolve_names_impl(const std::string& name,
                                       std::vector<folder_id> parent_folder_ids,
                                       bool return_full_contact_data,
-                                      searchscope scope,
+                                      search_scope scope,
                                       contact_data_shape shape)
     {
         auto version = get_request_server_version();

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -17967,8 +17967,15 @@ public:
     //! ContactDataShape and ReturnFullContactData are set by default. A
     //! directory_id is returned in place of the contact.
     resolution_set resolve_names(const std::string& unresolved_entry,
-                                 search_scope scope,
-                                 std::vector<folder_id> parent_folder_ids = {})
+                                 search_scope scope)
+    {
+        return resolve_names_impl(unresolved_entry, {}, true, scope,
+                                  contact_data_shape::id_only);
+    }
+
+    resolution_set
+    resolve_names(const std::string& unresolved_entry, search_scope scope,
+                  const std::vector<folder_id>& parent_folder_ids)
     {
         return resolve_names_impl(unresolved_entry, parent_folder_ids, true,
                                   scope, contact_data_shape::id_only);

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18595,8 +18595,6 @@ private:
         {
             return resolution_set();
         }
-        EWS_ASSERT(!response_message.resolutions().resolutions.empty() &&
-                   "Expected at least one resolution");
         return response_message.resolutions();
     }
 };

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8202,6 +8202,7 @@ struct resolution_set final
     {
     }
 
+    bool empty() const EWS_NOEXCEPT { return resolutions.empty(); }
     bool includes_last_item_in_range;
     int indexed_paging_offset;
     int numerator_offset;

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8180,7 +8180,7 @@ static_assert(std::is_move_constructible<directory_id>::value, "");
 static_assert(std::is_move_assignable<directory_id>::value, "");
 #endif
 
-struct resolution
+struct resolution final
 {
     ews::mailbox mailbox;
     ews::directory_id directory_id;

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -6282,51 +6282,6 @@ namespace internal
 
 }
 
-enum class contact_data_shape
-{
-    id_only,
-    default_shape,
-    all_properties
-};
-
-namespace internal
-{
-    inline std::string enum_to_str(contact_data_shape s)
-    {
-        switch (s)
-        {
-        case contact_data_shape::id_only:
-            return "IdOnly";
-        case contact_data_shape::default_shape:
-            return "Default";
-        case contact_data_shape::all_properties:
-            return "AllProperties";
-        default:
-            throw exception("Bad enum value");
-        }
-    }
-
-    inline contact_data_shape str_to_contact_data_shape(const std::string& str)
-    {
-        if (str == "IdOnly")
-        {
-            return contact_data_shape::id_only;
-        }
-        else if (str == "Default")
-        {
-            return contact_data_shape::default_shape;
-        }
-        else if (str == "AllProperties")
-        {
-            return contact_data_shape::all_properties;
-        }
-        else
-        {
-            throw exception("Bad enum value");
-        }
-    }
-}
-
 //! Exception thrown when a request was not successful
 class exchange_error final : public exception
 {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8196,19 +8196,16 @@ static_assert(std::is_move_assignable<resolution>::value, "");
 
 struct resolution_set
 {
-    resolution_set()
+    explicit resolution_set()
+        : includes_last_item_in_range(true), indexed_paging_offset(0),
+          numerator_offset(0), absolute_denominator(0), total_items_in_view(0)
     {
-        indexed_paging_offset = 0;
-        numerator_offset = 0;
-        absolute_denominator = 0;
-        includes_last_item_in_range = true;
-        total_items_in_view = 0;
     }
 
+    bool includes_last_item_in_range;
     int indexed_paging_offset;
     int numerator_offset;
     int absolute_denominator;
-    bool includes_last_item_in_range;
     int total_items_in_view;
     std::vector<resolution> resolutions;
 };

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -9312,8 +9312,8 @@ namespace internal
         }
 
     private:
-        explicit resolve_names_response_message(response_result&& res,
-                                                resolution_set&& rset)
+        resolve_names_response_message(response_result&& res,
+                                       resolution_set&& rset)
             : response_message_base(std::move(res)),
               resolutions_(std::move(rset))
         {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -17949,7 +17949,8 @@ public:
     resolution_set resolve_names(const std::string& unresolved_entry,
                                  search_scope scope)
     {
-        return resolve_names_impl(unresolved_entry, {}, scope);
+        std::vector<folder_id> v;
+        return resolve_names_impl(unresolved_entry, v, scope);
     }
 
     //! \brief The ResolveNames operation resolves ambiguous email addresses and

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18558,9 +18558,10 @@ private:
         return response_message.items().front();
     }
 
-    resolution_set resolve_names_impl(const std::string& name,
-                                      std::vector<folder_id> parent_folder_ids,
-                                      search_scope scope)
+    resolution_set
+    resolve_names_impl(const std::string& name,
+                       const std::vector<folder_id>& parent_folder_ids,
+                       search_scope scope)
     {
         auto version = get_request_server_version();
         std::stringstream sstr;

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8153,10 +8153,22 @@ static_assert(std::is_move_constructible<mailbox>::value, "");
 static_assert(std::is_move_assignable<mailbox>::value, "");
 #endif
 
-struct directory_id
+class directory_id final
 {
+public:
+#ifdef EWS_HAS_DEFAULT_AND_DELETE
+    directory_id() = default;
+#else
     directory_id() {}
-    directory_id(std::string idstring) { id = idstring; }
+#endif
+    explicit directory_id(const std::string& str)
+     : id(str)
+    {}
+    const std::string& get_id() const EWS_NOEXCEPT
+    {
+        return id;
+    }
+private:
     std::string id;
 };
 
@@ -19021,8 +19033,8 @@ namespace internal
                             res->last_node()->local_name_size()))
                 {
                     auto contact_elem = res->last_node("t:Contact");
-                    reso.directory_id.id =
-                        contact_elem->first_node("t:DirectoryId")->value();
+                    directory_id id(contact_elem->first_node("t:DirectoryId")->value());
+                    reso.directory_id = id;
                 }
 
                 resolutions.resolutions.emplace_back(reso);

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8182,11 +8182,11 @@ static_assert(std::is_move_assignable<resolution>::value, "");
 
 struct resolution_set
 {
-    int indexed_paging_offset;
-    int numerator_offset;
-    int absolute_denominator;
-    bool includes_last_item_in_range;
-    int total_items_in_view;
+    int indexed_paging_offset = 0;
+    int numerator_offset = 0;
+    int absolute_denominator = 0;
+    bool includes_last_item_in_range = true;
+    int total_items_in_view = 0;
     std::vector<resolution> resolutions;
 };
 

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8162,14 +8162,14 @@ public:
     directory_id() {}
 #endif
     explicit directory_id(const std::string& str)
-     : id(str)
+     : id_(str)
     {}
     const std::string& get_id() const EWS_NOEXCEPT
     {
-        return id;
+        return id_;
     }
 private:
-    std::string id;
+    std::string id_;
 };
 
 #ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -17944,6 +17944,7 @@ public:
     //! Returns a resolution_set which contains a vector of resolutions.
     //! ContactDataShape and ReturnFullContactData are set by default. A
     //! directory_id is returned in place of the contact.
+    //! If no name can be resolved, an empty resolution_set is returned.
     resolution_set resolve_names(const std::string& unresolved_entry,
                                  search_scope scope)
     {
@@ -17960,6 +17961,7 @@ public:
     //! Returns a resolution_set which contains a vector of resolutions.
     //! ContactDataShape and ReturnFullContactData are set by default. A
     //! directory_id is returned in place of the contact.
+    //! If no name can be resolved, an empty resolution_set is returned.
     resolution_set
     resolve_names(const std::string& unresolved_entry, search_scope scope,
                   const std::vector<folder_id>& parent_folder_ids)
@@ -18589,7 +18591,7 @@ private:
             internal::resolve_names_response_message::parse(std::move(response));
         if (response_message.result().cls == response_class::error)
         {
-            throw exchange_error(response_message.result());
+            return resolution_set();
         }
         EWS_ASSERT(!response_message.resolutions().resolutions.empty() &&
                    "Expected at least one resolution");

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18599,6 +18599,10 @@ private:
         {
             return resolution_set();
         }
+        if (response_message.result().cls == response_class::error)
+        {
+            throw exchange_error(response_message.result());
+        }
         return response_message.resolutions();
     }
 };

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -19016,14 +19016,14 @@ namespace internal
                  res; res = res->next_sibling())
             {
                 EWS_ASSERT(res && "Expected <Resolution> element");
-                resolution reso;
+                resolution r;
 
                 if (compare("Mailbox", std::strlen("Mailbox"),
                             res->first_node()->local_name(),
                             res->first_node()->local_name_size()))
                 {
                     auto mailbox_elem = res->first_node("t:Mailbox");
-                    reso.mailbox = mailbox::from_xml_element(*mailbox_elem);
+                    r.mailbox = mailbox::from_xml_element(*mailbox_elem);
                 }
                 if (compare("Contact", std::strlen("Contact"),
                             res->last_node()->local_name(),
@@ -19031,10 +19031,10 @@ namespace internal
                 {
                     auto contact_elem = res->last_node("t:Contact");
                     directory_id id(contact_elem->first_node("t:DirectoryId")->value());
-                    reso.directory_id = id;
+                    r.directory_id = id;
                 }
 
-                resolutions.resolutions.emplace_back(reso);
+                resolutions.resolutions.emplace_back(r);
             }
         }
         return resolve_names_response_message(std::move(result),

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18592,7 +18592,10 @@ private:
         auto response = request(sstr.str());
         const auto response_message =
             internal::resolve_names_response_message::parse(std::move(response));
-        if (response_message.result().cls == response_class::error)
+        if (response_message.result().code ==
+                response_code::error_name_resolution_no_results ||
+            response_message.result().code ==
+                response_code::error_name_resolution_no_mailbox)
         {
             return resolution_set();
         }

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -9306,7 +9306,10 @@ namespace internal
     public:
         // defined below
         static resolve_names_response_message parse(http_response&& response);
-        const resolution_set& resolutionset() const { return resolutions_; }
+        const resolution_set& resolutions() const EWS_NOEXCEPT
+        {
+            return resolutions_;
+        }
 
     private:
         explicit resolve_names_response_message(response_result&& res,
@@ -18604,9 +18607,9 @@ private:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.resolutionset().resolutions.empty() &&
+        EWS_ASSERT(!response_message.resolutions().resolutions.empty() &&
                    "Expected at least one resolution");
-        return response_message.resolutionset();
+        return response_message.resolutions();
     }
 };
 

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -17927,8 +17927,7 @@ public:
     resolution_set resolve_names(const std::string& unresolved_entry,
                                  search_scope scope)
     {
-        return resolve_names_impl(unresolved_entry, {}, true, scope,
-                                  contact_data_shape::id_only);
+        return resolve_names_impl(unresolved_entry, {}, scope);
     }
 
     //! \brief The ResolveNames operation resolves ambiguous email addresses and
@@ -17945,8 +17944,7 @@ public:
     resolve_names(const std::string& unresolved_entry, search_scope scope,
                   const std::vector<folder_id>& parent_folder_ids)
     {
-        return resolve_names_impl(unresolved_entry, parent_folder_ids, true,
-                                  scope, contact_data_shape::id_only);
+        return resolve_names_impl(unresolved_entry, parent_folder_ids, scope);
     }
 
 private:
@@ -18538,31 +18536,21 @@ private:
 
     resolution_set resolve_names_impl(const std::string& name,
                                       std::vector<folder_id> parent_folder_ids,
-                                      bool return_full_contact_data,
-                                      search_scope scope,
-                                      contact_data_shape shape)
+                                      search_scope scope)
     {
         auto version = get_request_server_version();
         std::stringstream sstr;
         sstr << "<m:ResolveNames "
-             << "ReturnFullContactData=\"";
-        if (return_full_contact_data)
-        {
-            sstr << "true";
-        }
-        else
-        {
-            sstr << "false";
-        }
-        sstr << "\" "
+             << "ReturnFullContactData=\""
+             << "true"
+             << "\" "
              << "SearchScope=\"" << internal::enum_to_str(scope) << "\" ";
 
         if (version == server_version::exchange_2010_sp2 ||
             version == server_version::exchange_2013 ||
             version == server_version::exchange_2013_sp1)
         {
-            sstr << "ContactDataShape=\"" << internal::enum_to_str(shape)
-                 << "\"";
+            sstr << "ContactDataShape=\"IdOnly\"";
         }
         sstr << ">";
         if (parent_folder_ids.size() > 0)

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -17966,11 +17966,12 @@ public:
     //! Returns a resolution_set which contains a vector<resolution>.
     //! ContactDataShape and ReturnFullContactData are set by default. A
     //! directory_id is returned in place of the contact.
-    resolution_set resolve_names(const std::string& name, search_scope scope,
+    resolution_set resolve_names(const std::string& unresolved_entry,
+                                 search_scope scope,
                                  std::vector<folder_id> parent_folder_ids = {})
     {
-        return resolve_names_impl(name, parent_folder_ids, true, scope,
-                                  contact_data_shape::id_only);
+        return resolve_names_impl(unresolved_entry, parent_folder_ids, true,
+                                  scope, contact_data_shape::id_only);
     }
 
 private:

--- a/include/ews/ews_fwd.hpp
+++ b/include/ews/ews_fwd.hpp
@@ -74,6 +74,8 @@ class update;
 class user_id;
 struct autodiscover_result;
 struct autodiscover_hints;
+struct resolution;
+struct resolution_set;
 template <typename T> class basic_service;
 bool operator==(const date_time&, const date_time&);
 bool operator==(const property_path&, const property_path&);

--- a/include/ews/ews_fwd.hpp
+++ b/include/ews/ews_fwd.hpp
@@ -41,6 +41,7 @@ class contains;
 class date_time;
 class delegate_user;
 class distinguished_folder_id;
+class directory_id;
 class duration;
 class exception;
 class exchange_error;

--- a/tests/assets/resolve_names_error.xml
+++ b/tests/assets/resolve_names_error.xml
@@ -1,0 +1,16 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+        <s:Header>
+                <h:ServerVersionInfo MajorVersion="15" MinorVersion="0" MajorBuildNumber="847" MinorBuildNumber="31" Version="V2_8" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+        </s:Header>
+        <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                <m:ResolveNamesResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+                        <m:ResponseMessages>
+                                <m:ResolveNamesResponseMessage ResponseClass="Error">
+                                        <m:MessageText>Es wurden keine Ergebnisse gefunden.</m:MessageText>
+                                        <m:ResponseCode>ErrorNameResolutionNoResults</m:ResponseCode>
+                                        <m:DescriptiveLinkKey>0</m:DescriptiveLinkKey>
+                                </m:ResolveNamesResponseMessage>
+                        </m:ResponseMessages>
+                </m:ResolveNamesResponse>
+        </s:Body>
+</s:Envelope>

--- a/tests/assets/resolve_names_response.xml
+++ b/tests/assets/resolve_names_response.xml
@@ -1,0 +1,28 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Header>
+    <h:ServerVersionInfo MajorVersion="15" MinorVersion="0" MajorBuildNumber="1178" MinorBuildNumber="2" Version="V2_23" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+  </s:Header>
+  <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <m:ResolveNamesResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+      <m:ResponseMessages>
+        <m:ResolveNamesResponseMessage ResponseClass="Success">
+          <m:ResponseCode>NoError</m:ResponseCode>
+          <m:ResolutionSet TotalItemsInView="1" IncludesLastItemInRange="true">
+            <t:Resolution>
+              <t:Mailbox>
+                <t:Name>User2</t:Name>
+                <t:EmailAddress>User2@example.com</t:EmailAddress>
+                <t:RoutingType>SMTP</t:RoutingType>
+                <t:MailboxType>Mailbox</t:MailboxType>
+              </t:Mailbox>
+              <t:Contact>
+                <t:ContactSource>ActiveDirectory</t:ContactSource>
+                <t:DirectoryId>&lt;GUID=abc-123-foo-bar&gt;</t:DirectoryId>
+              </t:Contact>
+            </t:Resolution>
+          </m:ResolutionSet>
+        </m:ResolveNamesResponseMessage>
+      </m:ResponseMessages>
+    </m:ResolveNamesResponse>
+  </s:Body>
+</s:Envelope>

--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -412,6 +412,7 @@ private:
     ews::message message_;
 };
 
+#ifdef EWS_USE_BOOST_LIBRARY
 class ResolveNamesTest : public FakeServiceFixture
 {
 public:
@@ -421,7 +422,6 @@ public:
     }
 };
 
-#ifdef EWS_USE_BOOST_LIBRARY
 class TemporaryDirectoryFixture : public BaseFixture
 {
 public:

--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -412,6 +412,15 @@ private:
     ews::message message_;
 };
 
+class ResolveNamesTest : public FakeServiceFixture
+{
+public:
+    const boost::filesystem::path assets_dir() const
+    {
+        return boost::filesystem::path(assets());
+    }
+};
+
 #ifdef EWS_USE_BOOST_LIBRARY
 class TemporaryDirectoryFixture : public BaseFixture
 {

--- a/tests/test_resolve_names.cpp
+++ b/tests/test_resolve_names.cpp
@@ -45,7 +45,7 @@ TEST_F(ResolveNamesTest, UserFound)
     auto resolution_id = response.resolutions[0].directory_id;
     EXPECT_EQ(resolution_mailbox.name(), "User2");
     EXPECT_EQ(resolution_mailbox.value(), "User2@example.com");
-    EXPECT_EQ(resolution_id.id, "<GUID=abc-123-foo-bar>");
+    EXPECT_EQ(resolution_id.get_id(), "<GUID=abc-123-foo-bar>");
 }
 
 TEST_F(ResolveNamesTest, SendCorrectRequest)

--- a/tests/test_resolve_names.cpp
+++ b/tests/test_resolve_names.cpp
@@ -1,0 +1,62 @@
+//   Copyright 2017 otris software AG
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//   This project is hosted at https://github.com/otris
+
+#include "fixtures.hpp"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace tests
+{
+TEST_F(ResolveNamesTest, NoUserFound)
+{
+    set_next_fake_response(read_file(assets_dir() / "resolve_names_error.xml"));
+
+    EXPECT_THROW(
+        {
+            auto result = service().resolve_names(
+                "name", ews::search_scope::active_directory);
+        },
+        ews::exception);
+}
+TEST_F(ResolveNamesTest, UserFound)
+{
+    set_next_fake_response(
+        read_file(assets_dir() / "resolve_names_response.xml"));
+
+    auto response =
+        service().resolve_names("name", ews::search_scope::active_directory);
+    auto resolution_mailbox = response.resolutions[0].mailbox;
+    auto resolution_id = response.resolutions[0].directory_id;
+    EXPECT_EQ(resolution_mailbox.name(), "User2");
+    EXPECT_EQ(resolution_mailbox.value(), "User2@example.com");
+    EXPECT_EQ(resolution_id.id, "<GUID=abc-123-foo-bar>");
+}
+
+TEST_F(ResolveNamesTest, SendCorrectRequest)
+{
+    auto response =
+        service().resolve_names("name", ews::search_scope::active_directory);
+    EXPECT_NE(get_last_request().request_string().find(
+                  "<soap:Body>"
+                  "<m:ResolveNames ReturnFullContactData=\"true\" "
+                  "SearchScope=\"ActiveDirectory\" ContactDataShape=\"IdOnly\">"
+                  "<m:UnresolvedEntry>name</m:UnresolvedEntry>"
+                  "</m:ResolveNames>"),
+              std::string::npos);
+}
+}

--- a/tests/test_resolve_names.cpp
+++ b/tests/test_resolve_names.cpp
@@ -27,12 +27,9 @@ TEST_F(ResolveNamesTest, NoUserFound)
 {
     set_next_fake_response(read_file(assets_dir() / "resolve_names_error.xml"));
 
-    EXPECT_THROW(
-        {
-            auto result = service().resolve_names(
-                "name", ews::search_scope::active_directory);
-        },
-        ews::exception);
+    auto result =
+        service().resolve_names("name", ews::search_scope::active_directory);
+    EXPECT_TRUE(result.empty());
 }
 TEST_F(ResolveNamesTest, UserFound)
 {

--- a/tests/test_resolve_names.cpp
+++ b/tests/test_resolve_names.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#ifdef EWS_USE_BOOST_LIBRARY
 namespace tests
 {
 TEST_F(ResolveNamesTest, NoUserFound)
@@ -60,3 +61,5 @@ TEST_F(ResolveNamesTest, SendCorrectRequest)
               std::string::npos);
 }
 }
+
+#endif // EWS_USE_BOOST_LIBRARY


### PR DESCRIPTION
This pull request closes #73 . 

The contact part of the resolution only contains the DirectoryId, because the returned response from the exchange server doesn't include an ItemId, which is needed for creation of a contact.

Also, because of this fact, the function now only needs the name to look for, the ParentFolderIds and the searchscope.