### PR TITLE
Add null terminator to read_file func

### DIFF
--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -77,6 +77,7 @@ inline std::vector<char> read_file(const boost::filesystem::path& path)
                     std::istream_iterator<unsigned char>(ifstr),
                     std::istream_iterator<unsigned char>());
     ifstr.close();
+    contents.push_back('\0');
     return contents;
 }
 #endif // EWS_USE_BOOST_LIBRARY

--- a/tests/test_attachments.cpp
+++ b/tests/test_attachments.cpp
@@ -204,7 +204,6 @@ TEST_F(FileAttachmentTest, ItemAttachmentFromXML)
 
     std::vector<char> buf =
         read_file(assets_dir() / "get_attachment_response_item.xml");
-    buf.push_back('\0');
     xml_document doc;
     doc.parse<0>(&buf[0]);
     auto node = get_element_by_qname(doc, "ItemAttachment",
@@ -256,7 +255,6 @@ TEST_F(FileAttachmentTest, WriteContentToFile)
     const auto target_path = cwd() / "output.png";
     std::vector<char> buf =
         read_file(assets_dir() / "get_attachment_response.xml");
-    buf.push_back('\0');
     xml_document doc;
     doc.parse<0>(&buf[0]);
     auto node =
@@ -345,7 +343,6 @@ TEST_F(FileAttachmentTest, FileAttachmentFromXML)
 
     std::vector<char> buf =
         read_file(assets_dir() / "get_attachment_response.xml");
-    buf.push_back('\0');
     xml_document doc;
     doc.parse<0>(&buf[0]);
     auto node = get_element_by_qname(doc, "FileAttachment",


### PR DESCRIPTION
This commit adds a `\0` to the vector returned from the read_file overload, and removes the unnecessary push_backs in the attachment_tests.