### PR TITLE
WIP: Implement notification operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,15 @@ if(HAS_INITIALIZER_LISTS)
     add_definitions(-DEWS_HAS_INITIALIZER_LISTS)
 endif()
 
+# Test support for std::variant
+CHECK_CXX_SOURCE_COMPILES("
+#include <variant>
+int main() { std::variant<int, float> v; }
+" HAS_VARIANT)
+if(HAS_VARIANT)
+    add_definitions(-DEWS_HAS_VARIANT)
+endif()
+
 # Helper function for all those example executables
 function(add_example EXAMPLE_NAME)
     add_executable(${EXAMPLE_NAME}
@@ -344,6 +353,9 @@ add_example(remove_delegate)
 add_example(resolve_names)
 add_example(send_message)
 add_example(sync_folder_items)
+if(HAS_VARIANT)
+    add_example(subscribe)
+endif()
 add_example(update_contact)
 
 # Python is optional as it is only used by TimeoutTest
@@ -380,6 +392,7 @@ add_executable(tests
     tests/test_resolve_names.cpp
     tests/test_restrictions.cpp
     tests/test_service.cpp
+    tests/test_subscribe.cpp
     tests/test_tasks.cpp
     tests/test_timeout.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,10 +376,7 @@ add_subdirectory(${GTEST_ROOT} EXCLUDE_FROM_ALL)
 include_directories(${GTEST_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
 if(!HAS_VARIANT)
-add_executable(tests
-    ${ews_SOURCES}
-    ${rapidxml_SOURCES}
-    tests/fixtures.hpp
+set(ews_TESTS tests/fixtures.hpp
     tests/main.cpp
     tests/regressions/91.cpp
     tests/test_attachments.cpp
@@ -398,10 +395,7 @@ add_executable(tests
 endif()
 
 if(HAS_VARIANT)
-add_executable(tests
-    ${ews_SOURCES}
-    ${rapidxml_SOURCES}
-    tests/fixtures.hpp
+set(ews_TESTS tests/fixtures.hpp
     tests/main.cpp
     tests/regressions/91.cpp
     tests/test_attachments.cpp
@@ -419,6 +413,11 @@ add_executable(tests
     tests/test_tasks.cpp
     tests/test_timeout.cpp)
 endif()
+
+add_executable(tests
+    ${ews_SOURCES}
+    ${rapidxml_SOURCES}
+    ${ews_TESTS})
 
 if(Boost_FOUND)
     target_link_libraries(tests ${GTEST_LIBRARIES} ${CURL_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,29 @@ endif()
 add_subdirectory(${GTEST_ROOT} EXCLUDE_FROM_ALL)
 include_directories(${GTEST_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
+if(!HAS_VARIANT)
+add_executable(tests
+    ${ews_SOURCES}
+    ${rapidxml_SOURCES}
+    tests/fixtures.hpp
+    tests/main.cpp
+    tests/regressions/91.cpp
+    tests/test_attachments.cpp
+    tests/test_autodiscover.cpp
+    tests/test_calendar_items.cpp
+    tests/test_contacts.cpp
+    tests/test_folders.cpp
+    tests/test_internals.cpp
+    tests/test_items.cpp
+    tests/test_messages.cpp
+    tests/test_resolve_names.cpp
+    tests/test_restrictions.cpp
+    tests/test_service.cpp
+    tests/test_tasks.cpp
+    tests/test_timeout.cpp)
+endif()
+
+if(HAS_VARIANT)
 add_executable(tests
     ${ews_SOURCES}
     ${rapidxml_SOURCES}
@@ -395,6 +418,7 @@ add_executable(tests
     tests/test_subscribe.cpp
     tests/test_tasks.cpp
     tests/test_timeout.cpp)
+endif()
 
 if(Boost_FOUND)
     target_link_libraries(tests ${GTEST_LIBRARIES} ${CURL_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,6 @@ endif()
 add_subdirectory(${GTEST_ROOT} EXCLUDE_FROM_ALL)
 include_directories(${GTEST_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
-if(!HAS_VARIANT)
 set(ews_TESTS tests/fixtures.hpp
     tests/main.cpp
     tests/regressions/91.cpp
@@ -392,26 +391,11 @@ set(ews_TESTS tests/fixtures.hpp
     tests/test_service.cpp
     tests/test_tasks.cpp
     tests/test_timeout.cpp)
-endif()
 
 if(HAS_VARIANT)
-set(ews_TESTS tests/fixtures.hpp
-    tests/main.cpp
-    tests/regressions/91.cpp
-    tests/test_attachments.cpp
-    tests/test_autodiscover.cpp
-    tests/test_calendar_items.cpp
-    tests/test_contacts.cpp
-    tests/test_folders.cpp
-    tests/test_internals.cpp
-    tests/test_items.cpp
-    tests/test_messages.cpp
-    tests/test_resolve_names.cpp
-    tests/test_restrictions.cpp
-    tests/test_service.cpp
-    tests/test_subscribe.cpp
-    tests/test_tasks.cpp
-    tests/test_timeout.cpp)
+set(ews_TESTS
+    ${ews_TESTS}
+    tests/test_subscribe.cpp)
 endif()
 
 add_executable(tests

--- a/examples/subscribe.cpp
+++ b/examples/subscribe.cpp
@@ -65,7 +65,8 @@ int main()
         {
             std::visit(
                 overloaded{
-                    [](auto&& arg) {
+                    [](auto&&) { /* do nothing */ },
+                    [](ews::created_event arg) {
                         std::cout << "EventType: "
                                   << ews::internal::enum_to_str(arg.get_type())
                                   << std::endl;
@@ -73,13 +74,7 @@ int main()
                                   << std::endl;
                         std::cout << "Timestamp: " << arg.get_timestamp()
                                   << std::endl;
-                    },
-                    [](ews::status_event arg) {
-                        std::cout << "EventType: "
-                                  << ews::internal::enum_to_str(arg.get_type())
-                                  << std::endl;
-                        std::cout << "Watermark: " << arg.get_watermark()
-                                  << std::endl;
+
                     }},
                 e);
         }

--- a/examples/subscribe.cpp
+++ b/examples/subscribe.cpp
@@ -23,11 +23,14 @@
 #include <ostream>
 #include <string>
 
+namespace
+{
 template <class... Ts> struct overloaded : Ts...
 {
     using Ts::operator()...;
 };
 template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;
+}
 
 int main()
 {

--- a/examples/subscribe.cpp
+++ b/examples/subscribe.cpp
@@ -1,0 +1,97 @@
+//   Copyright 2018 otris software AG
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#include <ews/ews.hpp>
+#include <ews/ews_test_support.hpp>
+
+#include <chrono>
+#include <thread>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <ostream>
+#include <string>
+
+template <class... Ts> struct overloaded : Ts...
+{
+    using Ts::operator()...;
+};
+template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;
+
+int main()
+{
+    int res = EXIT_SUCCESS;
+    ews::set_up();
+
+    try
+    {
+        const auto env = ews::test::environment();
+        auto service = ews::service(env.server_uri, env.domain, env.username,
+                                    env.password);
+
+        // Subscribe to all <CreatedEvents> in inbox
+        auto sub_info = service.subscribe({ews::standard_folder::inbox},
+                                          {ews::event_type::created_event}, 10);
+
+        // Create and send a message to trigger an event
+        auto message = ews::message();
+        message.set_to_recipients({ews::mailbox("test2@otris.de")});
+        service.create_item(message,
+                            ews::message_disposition::send_and_save_copy);
+
+        // Wait for the event to be created
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+
+        // Get and check the created_event.
+        // This way, we can get all the needed information from the events for
+        // further handling.
+        auto notification = service.get_events(sub_info.get_subscription_id(),
+                                         sub_info.get_watermark());
+        std::cout << "SubscriptionId: " << notification.subscription_id
+                  << std::endl;
+        std::cout << "MoreEvents: " << notification.more_events << std::endl;
+        for (auto& e : notification.events)
+        {
+            std::visit(
+                overloaded{
+                    [](auto&& arg) {
+                        std::cout << "EventType: "
+                                  << ews::internal::enum_to_str(arg.get_type())
+                                  << std::endl;
+                        std::cout << "Watermark: " << arg.get_watermark()
+                                  << std::endl;
+                        std::cout << "Timestamp: " << arg.get_timestamp()
+                                  << std::endl;
+                    },
+                    [](ews::status_event arg) {
+                        std::cout << "EventType: "
+                                  << ews::internal::enum_to_str(arg.get_type())
+                                  << std::endl;
+                        std::cout << "Watermark: " << arg.get_watermark()
+                                  << std::endl;
+                    }},
+                e);
+        }
+
+        service.unsubscribe(sub_info.get_subscription_id());
+    }
+    catch (std::exception& exc)
+    {
+        std::cout << exc.what() << std::endl;
+        res = EXIT_FAILURE;
+    }
+
+    ews::tear_down();
+    return res;
+}

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8913,7 +8913,7 @@ namespace internal
     };
 }
 //! Represents a <CopiedEvent>
-class copied_event : public internal::event_base
+class copied_event final : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9018,7 +9018,7 @@ private:
 };
 
 //! Represents a <CreatedEvent>
-class created_event : public internal::event_base
+class created_event final : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9088,7 +9088,7 @@ private:
 };
 
 //! Represents a <DeletedEvent>
-class deleted_event : public internal::event_base
+class deleted_event final : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9160,7 +9160,7 @@ private:
 };
 
 //! Represents a <ModifiedEvent>
-class modified_event : public internal::event_base
+class modified_event final : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9241,7 +9241,7 @@ private:
 };
 
 //! Represents a <MovedEvent>
-class moved_event : public internal::event_base
+class moved_event final : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9346,7 +9346,7 @@ private:
 };
 
 //! Represents a <NewMailEvent>
-class new_mail_event : public internal::event_base
+class new_mail_event final : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9409,7 +9409,7 @@ private:
 };
 
 //! Represents a <StatusEvent>
-class status_event : public internal::event_base
+class status_event final : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9438,7 +9438,7 @@ public:
 };
 
 //! Represents a <FreeBusyChangedEvent>
-class free_busy_changed_event : public internal::event_base
+class free_busy_changed_event final : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8896,8 +8896,24 @@ static_assert(std::is_move_assignable<distinguished_folder_id>::value, "");
 #endif
 
 #ifdef EWS_HAS_VARIANT
+namespace internal
+{
+    class event_base
+    {
+    public:
+        const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+        const std::string& get_watermark() const EWS_NOEXCEPT
+        {
+            return watermark_;
+        }
+
+    protected:
+        event_type type_;
+        std::string watermark_;
+    };
+}
 //! Represents a <CopiedEvent>
-class copied_event final
+class copied_event : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -8974,8 +8990,6 @@ public:
         return e;
     };
 
-    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
-    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
     const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
     const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
     const item_id& get_old_item_id() const EWS_NOEXCEPT { return old_item_id_; }
@@ -8994,8 +9008,6 @@ public:
     }
 
 private:
-    event_type type_;
-    std::string watermark_;
     std::string timestamp_;
     item_id id_;
     item_id old_item_id_;
@@ -9006,7 +9018,7 @@ private:
 };
 
 //! Represents a <CreatedEvent>
-class created_event final
+class created_event : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9060,8 +9072,6 @@ public:
         return e;
     };
 
-    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
-    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
     const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
     const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
     const folder_id& get_folder_id() const EWS_NOEXCEPT { return folder_id_; }
@@ -9071,8 +9081,6 @@ public:
     }
 
 private:
-    event_type type_;
-    std::string watermark_;
     std::string timestamp_;
     item_id id_;
     folder_id folder_id_;
@@ -9080,7 +9088,7 @@ private:
 };
 
 //! Represents a <DeletedEvent>
-class deleted_event final
+class deleted_event : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9136,8 +9144,6 @@ public:
         return e;
     };
 
-    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
-    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
     const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
     const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
     const folder_id& get_folder_id() const EWS_NOEXCEPT { return folder_id_; }
@@ -9147,8 +9153,6 @@ public:
     }
 
 private:
-    event_type type_;
-    std::string watermark_;
     std::string timestamp_;
     item_id id_;
     folder_id folder_id_;
@@ -9156,7 +9160,7 @@ private:
 };
 
 //! Represents a <ModifiedEvent>
-class modified_event final
+class modified_event : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9219,8 +9223,6 @@ public:
         return e;
     };
 
-    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
-    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
     const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
     const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
     const folder_id& get_folder_id() const EWS_NOEXCEPT { return folder_id_; }
@@ -9231,8 +9233,6 @@ public:
     const int& get_unread_count() const EWS_NOEXCEPT { return unread_count_; }
 
 private:
-    event_type type_;
-    std::string watermark_;
     std::string timestamp_;
     int unread_count_;
     item_id id_;
@@ -9241,7 +9241,7 @@ private:
 };
 
 //! Represents a <MovedEvent>
-class moved_event final
+class moved_event : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9318,8 +9318,6 @@ public:
         return e;
     };
 
-    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
-    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
     const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
     const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
     const item_id& get_old_item_id() const EWS_NOEXCEPT { return old_item_id_; }
@@ -9338,8 +9336,6 @@ public:
     }
 
 private:
-    event_type type_;
-    std::string watermark_;
     std::string timestamp_;
     item_id id_;
     item_id old_item_id_;
@@ -9350,7 +9346,7 @@ private:
 };
 
 //! Represents a <NewMailEvent>
-class new_mail_event final
+class new_mail_event : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9399,8 +9395,6 @@ public:
         return e;
     };
 
-    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
-    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
     const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
     const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
     const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
@@ -9409,15 +9403,13 @@ public:
     }
 
 private:
-    event_type type_;
-    std::string watermark_;
     std::string timestamp_;
     item_id id_;
     folder_id parent_folder_id_;
 };
 
 //! Represents a <StatusEvent>
-class status_event final
+class status_event : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9425,14 +9417,10 @@ public:
 #else
     status_event() {}
 #endif
-    explicit status_event(event_type type, std::string watermark)
-        : type_(std::move(type)), watermark_(std::move(watermark))
-    {
-    }
-
     static status_event from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
+        status_event e;
         std::string watermark;
         for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
@@ -9442,19 +9430,15 @@ public:
                 watermark = std::string(node->value(), node->value_size());
             }
         }
-        return status_event(event_type::status_event, watermark);
+        e.type_ = event_type::new_mail_event;
+        e.watermark_ = watermark;
+        return e;
     };
 
-    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
-    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
-
-private:
-    event_type type_;
-    std::string watermark_;
 };
 
 //! Represents a <FreeBusyChangedEvent>
-class free_busy_changed_event final
+class free_busy_changed_event : public internal::event_base
 {
 public:
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -9462,12 +9446,6 @@ public:
 #else
     free_busy_changed_event() {}
 #endif
-    explicit free_busy_changed_event(event_type type, std::string watermark,
-                                     std::string timestamp, item_id id)
-        : type_(std::move(type)), watermark_(std::move(watermark)),
-          timestamp_(std::move(timestamp)), id_(std::move(id))
-    {
-    }
 
     static free_busy_changed_event
     from_xml_element(const rapidxml::xml_node<>& elem)
@@ -9510,8 +9488,6 @@ public:
         return e;
     };
 
-    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
-    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
     const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
     const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
     const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
@@ -9520,8 +9496,6 @@ public:
     }
 
 private:
-    event_type type_;
-    std::string watermark_;
     std::string timestamp_;
     item_id id_;
     folder_id parent_folder_id_;

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8906,7 +8906,7 @@ public:
     copied_event() {}
 #endif
 
-    static copied_event from_xml_element(rapidxml::xml_node<char>* elem)
+    static copied_event from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
         copied_event e;
@@ -8918,7 +8918,7 @@ public:
         folder_id old_f_id;
         folder_id parent_folder_id;
         folder_id old_parent_folder_id;
-        for (auto node = elem->first_node(); node; node = node->next_sibling())
+        for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),
                         "Watermark", strlen("Watermark")))
@@ -9014,7 +9014,7 @@ public:
 #else
     created_event() {}
 #endif
-    static created_event from_xml_element(rapidxml::xml_node<char>* elem)
+    static created_event from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
         created_event e;
@@ -9023,7 +9023,7 @@ public:
         item_id id;
         folder_id f_id;
         folder_id parent_folder_id;
-        for (auto node = elem->first_node(); node; node = node->next_sibling())
+        for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),
                         "Watermark", strlen("Watermark")))
@@ -9089,7 +9089,7 @@ public:
     deleted_event() {}
 #endif
 
-    static deleted_event from_xml_element(rapidxml::xml_node<char>* elem)
+    static deleted_event from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
         deleted_event e;
@@ -9098,7 +9098,7 @@ public:
         item_id id;
         folder_id f_id;
         folder_id parent_folder_id;
-        for (auto node = elem->first_node(); node; node = node->next_sibling())
+        for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),
                         "Watermark", strlen("Watermark")))
@@ -9165,7 +9165,7 @@ public:
     modified_event() {}
 #endif
 
-    static modified_event from_xml_element(rapidxml::xml_node<char>* elem)
+    static modified_event from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
         modified_event e;
@@ -9175,7 +9175,7 @@ public:
         folder_id f_id;
         folder_id parent_folder_id;
         int unread_count;
-        for (auto node = elem->first_node(); node; node = node->next_sibling())
+        for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),
                         "Watermark", strlen("Watermark")))
@@ -9250,7 +9250,7 @@ public:
     moved_event() {}
 #endif
 
-    static moved_event from_xml_element(rapidxml::xml_node<char>* elem)
+    static moved_event from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
         moved_event e;
@@ -9262,7 +9262,7 @@ public:
         folder_id old_f_id;
         folder_id parent_folder_id;
         folder_id old_parent_folder_id;
-        for (auto node = elem->first_node(); node; node = node->next_sibling())
+        for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),
                         "Watermark", strlen("Watermark")))
@@ -9359,7 +9359,7 @@ public:
     new_mail_event() {}
 #endif
 
-    static new_mail_event from_xml_element(rapidxml::xml_node<char>* elem)
+    static new_mail_event from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
         new_mail_event e;
@@ -9367,7 +9367,7 @@ public:
         std::string timestamp;
         item_id id;
         folder_id parent_folder_id;
-        for (auto node = elem->first_node(); node; node = node->next_sibling())
+        for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),
                         "Watermark", strlen("Watermark")))
@@ -9430,11 +9430,11 @@ public:
     {
     }
 
-    static status_event from_xml_element(rapidxml::xml_node<char>* elem)
+    static status_event from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
         std::string watermark;
-        for (auto node = elem->first_node(); node; node = node->next_sibling())
+        for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),
                         "Watermark", strlen("Watermark")))
@@ -9470,7 +9470,7 @@ public:
     }
 
     static free_busy_changed_event
-    from_xml_element(rapidxml::xml_node<char>* elem)
+    from_xml_element(const rapidxml::xml_node<>& elem)
     {
         using rapidxml::internal::compare;
         free_busy_changed_event e;
@@ -9478,7 +9478,7 @@ public:
         std::string timestamp;
         item_id id;
         folder_id parent_folder_id;
-        for (auto node = elem->first_node(); node; node = node->next_sibling())
+        for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),
                         "Watermark", strlen("Watermark")))
@@ -21233,7 +21233,7 @@ namespace internal
             {
                 auto e = notification_element->first_node_ns(
                     uri<>::microsoft::types(), "StatusEvent");
-                status_event s = status_event::from_xml_element(e);
+                status_event s = status_event::from_xml_element(*e);
                 n.events.emplace_back(s);
             }
             else
@@ -21242,42 +21242,42 @@ namespace internal
                          uri<>::microsoft::types(), "CopiedEvent");
                      res; res = res->next_sibling())
                 {
-                    copied_event c = copied_event::from_xml_element(res);
+                    copied_event c = copied_event::from_xml_element(*res);
                     n.events.emplace_back(c);
                 }
                 for (auto res = notification_element->first_node_ns(
                          uri<>::microsoft::types(), "CreatedEvent");
                      res; res = res->next_sibling())
                 {
-                    created_event c = created_event::from_xml_element(res);
+                    created_event c = created_event::from_xml_element(*res);
                     n.events.emplace_back(c);
                 }
                 for (auto res = notification_element->first_node_ns(
                          uri<>::microsoft::types(), "DeletedEvent");
                      res; res = res->next_sibling())
                 {
-                    deleted_event d = deleted_event::from_xml_element(res);
+                    deleted_event d = deleted_event::from_xml_element(*res);
                     n.events.emplace_back(d);
                 }
                 for (auto res = notification_element->first_node_ns(
                          uri<>::microsoft::types(), "ModifiedEvent");
                      res; res = res->next_sibling())
                 {
-                    modified_event d = modified_event::from_xml_element(res);
+                    modified_event d = modified_event::from_xml_element(*res);
                     n.events.emplace_back(d);
                 }
                 for (auto res = notification_element->first_node_ns(
                          uri<>::microsoft::types(), "MovedEvent");
                      res; res = res->next_sibling())
                 {
-                    moved_event m = moved_event::from_xml_element(res);
+                    moved_event m = moved_event::from_xml_element(*res);
                     n.events.emplace_back(m);
                 }
                 for (auto res = notification_element->first_node_ns(
                          uri<>::microsoft::types(), "NewMailEvent");
                      res; res = res->next_sibling())
                 {
-                    new_mail_event m = new_mail_event::from_xml_element(res);
+                    new_mail_event m = new_mail_event::from_xml_element(*res);
                     n.events.emplace_back(m);
                 }
                 for (auto res = notification_element->first_node_ns(
@@ -21285,7 +21285,7 @@ namespace internal
                      res; res = res->next_sibling())
                 {
                     free_busy_changed_event f =
-                        free_busy_changed_event::from_xml_element(res);
+                        free_busy_changed_event::from_xml_element(*res);
                     n.events.emplace_back(f);
                 }
             }

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8974,15 +8974,24 @@ public:
         return e;
     };
 
-    event_type get_type() { return type_; }
-    std::string get_watermark() { return watermark_; }
-    std::string get_timestamp() { return timestamp_; }
-    item_id get_item_id() { return id_; }
-    item_id get_old_item_id() { return old_item_id_; }
-    folder_id get_folder_id() { return folder_id_; }
-    folder_id get_old_folder_id() { return old_folder_id_; }
-    folder_id get_parent_folder_id() { return parent_folder_id_; }
-    folder_id get_old_parent_folder_id() { return old_parent_folder_id_; }
+    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
+    const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
+    const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
+    const item_id& get_old_item_id() const EWS_NOEXCEPT { return old_item_id_; }
+    const folder_id& get_folder_id() const EWS_NOEXCEPT { return folder_id_; }
+    const folder_id& get_old_folder_id() const EWS_NOEXCEPT
+    {
+        return old_folder_id_;
+    }
+    const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return parent_folder_id_;
+    }
+    const folder_id& get_old_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return old_parent_folder_id_;
+    }
 
 private:
     event_type type_;
@@ -9051,12 +9060,15 @@ public:
         return e;
     };
 
-    event_type get_type() { return type_; }
-    std::string get_watermark() { return watermark_; }
-    std::string get_timestamp() { return timestamp_; }
-    item_id get_item_id() { return id_; }
-    folder_id get_folder_id() { return folder_id_; }
-    folder_id get_parent_folder_id() { return parent_folder_id_; }
+    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
+    const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
+    const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
+    const folder_id& get_folder_id() const EWS_NOEXCEPT { return folder_id_; }
+    const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return parent_folder_id_;
+    }
 
 private:
     event_type type_;
@@ -9124,12 +9136,15 @@ public:
         return e;
     };
 
-    event_type get_type() { return type_; }
-    std::string get_watermark() { return watermark_; }
-    std::string get_timestamp() { return timestamp_; }
-    item_id get_item_id() { return id_; }
-    folder_id get_folder_id() { return folder_id_; }
-    folder_id get_parent_folder_id() { return parent_folder_id_; }
+    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
+    const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
+    const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
+    const folder_id& get_folder_id() const EWS_NOEXCEPT { return folder_id_; }
+    const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return parent_folder_id_;
+    }
 
 private:
     event_type type_;
@@ -9204,13 +9219,16 @@ public:
         return e;
     };
 
-    event_type get_type() { return type_; }
-    std::string get_watermark() { return watermark_; }
-    std::string get_timestamp() { return timestamp_; }
-    item_id get_item_id() { return id_; }
-    folder_id get_folder_id() { return folder_id_; }
-    folder_id get_parent_folder_id() { return parent_folder_id_; }
-    int get_unread_count() { return unread_count_; }
+    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
+    const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
+    const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
+    const folder_id& get_folder_id() const EWS_NOEXCEPT { return folder_id_; }
+    const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return parent_folder_id_;
+    }
+    const int& get_unread_count() const EWS_NOEXCEPT { return unread_count_; }
 
 private:
     event_type type_;
@@ -9300,15 +9318,24 @@ public:
         return e;
     };
 
-    event_type get_type() { return type_; }
-    std::string get_watermark() { return watermark_; }
-    std::string get_timestamp() { return timestamp_; }
-    item_id get_item_id() { return id_; }
-    item_id get_old_item_id() { return old_item_id_; }
-    folder_id get_folder_id() { return folder_id_; }
-    folder_id get_old_folder_id() { return old_folder_id_; }
-    folder_id get_parent_folder_id() { return parent_folder_id_; }
-    folder_id get_old_parent_folder_id() { return old_parent_folder_id_; }
+    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
+    const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
+    const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
+    const item_id& get_old_item_id() const EWS_NOEXCEPT { return old_item_id_; }
+    const folder_id& get_folder_id() const EWS_NOEXCEPT { return folder_id_; }
+    const folder_id& get_old_folder_id() const EWS_NOEXCEPT
+    {
+        return old_folder_id_;
+    }
+    const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return parent_folder_id_;
+    }
+    const folder_id& get_old_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return old_parent_folder_id_;
+    }
 
 private:
     event_type type_;
@@ -9372,11 +9399,14 @@ public:
         return e;
     };
 
-    event_type get_type() { return type_; }
-    std::string get_watermark() { return watermark_; }
-    std::string get_timestamp() { return timestamp_; }
-    item_id get_item_id() { return id_; }
-    folder_id get_parent_folder_id() { return parent_folder_id_; }
+    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
+    const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
+    const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
+    const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return parent_folder_id_;
+    }
 
 private:
     event_type type_;
@@ -9415,8 +9445,8 @@ public:
         return status_event(event_type::status_event, watermark);
     };
 
-    event_type get_type() { return type_; }
-    std::string get_watermark() { return watermark_; }
+    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
 
 private:
     event_type type_;
@@ -9480,11 +9510,14 @@ public:
         return e;
     };
 
-    event_type get_type() { return type_; }
-    std::string get_watermark() { return watermark_; }
-    std::string get_timestamp() { return timestamp_; }
-    item_id get_item_id() { return id_; }
-    folder_id get_parent_folder_id() { return parent_folder_id_; }
+    const event_type& get_type() const EWS_NOEXCEPT { return type_; }
+    const std::string& get_watermark() const EWS_NOEXCEPT { return watermark_; }
+    const std::string& get_timestamp() const EWS_NOEXCEPT { return timestamp_; }
+    const item_id& get_item_id() const EWS_NOEXCEPT { return id_; }
+    const folder_id& get_parent_folder_id() const EWS_NOEXCEPT
+    {
+        return parent_folder_id_;
+    }
 
 private:
     event_type type_;

--- a/include/ews/ews_fwd.hpp
+++ b/include/ews/ews_fwd.hpp
@@ -38,8 +38,11 @@ class calendar_item;
 class connecting_sid;
 class contact;
 class contains;
+class copied_event;
+class created_event;
 class date_time;
 class delegate_user;
+class deleted_event;
 class directory_id;
 class distinguished_folder_id;
 class duration;
@@ -47,6 +50,7 @@ class exception;
 class exchange_error;
 class folder;
 class folder_id;
+class free_busy_changed_event;
 class http_error;
 class indexed_property_path;
 class internet_message_header;
@@ -61,6 +65,9 @@ class item_id;
 class mailbox;
 class message;
 class mime_content;
+class modified_event;
+class moved_event;
+class new_mail_event;
 class not_;
 class ntlm_credentials;
 class or_;
@@ -70,6 +77,7 @@ class property_path;
 class schema_validation_error;
 class search_expression;
 class soap_fault;
+class status_event;
 class task;
 class update;
 class user_id;
@@ -92,5 +100,4 @@ autodiscover_result get_exchange_web_services_url(const std::string&,
                                                   const basic_credentials&,
                                                   const autodiscover_hints&);
 }
-
 // vim:et ts=4 sw=4

--- a/tests/assets/subscribe_response.xml
+++ b/tests/assets/subscribe_response.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Header>
+    <t:ServerVersionInfo MajorVersion="8" MinorVersion="0" MajorBuildNumber="628" MinorBuildNumber="0"
+                         xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" />
+  </soap:Header>
+  <soap:Body>
+    <SubscribeResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                       xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                       xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+      <m:ResponseMessages>
+        <m:SubscribeResponseMessage ResponseClass="Success">
+          <m:ResponseCode>NoError</m:ResponseCode>
+          <m:SubscriptionId>abc-foo-123-456</m:SubscriptionId>
+          <m:Watermark>AAAAAHgGAAAAAAAAAQ==</m:Watermark>
+        </m:SubscribeResponseMessage>
+      </m:ResponseMessages>
+    </SubscribeResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -422,6 +422,15 @@ public:
     }
 };
 
+class SubscribeTest : public FakeServiceFixture
+{
+public:
+    const boost::filesystem::path assets_dir() const
+    {
+        return boost::filesystem::path(assets());
+    }
+};
+
 class TemporaryDirectoryFixture : public BaseFixture
 {
 public:

--- a/tests/test_subscribe.cpp
+++ b/tests/test_subscribe.cpp
@@ -1,0 +1,69 @@
+//   Copyright 2018 otris software AG
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//   This project is hosted at https://github.com/otris
+
+#ifdef EWS_HAS_VARIANT
+#include "fixtures.hpp"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifdef EWS_USE_BOOST_LIBRARY
+namespace tests
+{
+TEST_F(SubscribeTest, SubscriptionSuccessful)
+{
+    set_next_fake_response(
+        read_file(assets_dir() / "subscribe_response.xml"));
+
+    ews::distinguished_folder_id folder(ews::standard_folder::inbox);
+    auto type = ews::event_type::created_event;
+    std::vector<ews::distinguished_folder_id> folders = {folder};
+    std::vector<ews::event_type> types = {type};
+
+    auto response =
+        service().subscribe(folders, types, 10);
+    EXPECT_EQ(response.get_subscription_id(), "abc-foo-123-456");
+    EXPECT_EQ(response.get_watermark(), "AAAAAHgGAAAAAAAAAQ==");
+}
+
+TEST_F(SubscribeTest, SendCorrectRequest)
+{
+    ews::distinguished_folder_id folder(ews::standard_folder::inbox);
+    auto type = ews::event_type::new_mail_event;
+    std::vector<ews::distinguished_folder_id> folders = {folder};
+    std::vector<ews::event_type> types = {type};
+
+    auto response =
+        service().subscribe(folders, types, 10);
+    EXPECT_NE(get_last_request().request_string().find(
+                  "<soap:Body>"
+                  "<m:Subscribe>"
+                  "<m:PullSubscriptionRequest>"
+                  "<t:FolderIds>"
+                  "<t:DistinguishedFolderId Id=\"inbox\"/>"
+                  "</t:FolderIds>"
+                  "<t:EventTypes>"
+                  "<t:EventType>NewMailEvent</t:EventType>"
+                  "</t:EventTypes>"
+                  "<t:Timeout>10</t:Timeout>"
+                  "</m:PullSubscriptionRequest>"),
+              std::string::npos);
+}
+}
+
+#endif // EWS_USE_BOOST_LIBRARY
+#endif

--- a/tests/test_subscribe.cpp
+++ b/tests/test_subscribe.cpp
@@ -14,7 +14,6 @@
 //
 //   This project is hosted at https://github.com/otris
 
-#ifdef EWS_HAS_VARIANT
 #include "fixtures.hpp"
 
 #include <cstring>
@@ -66,4 +65,3 @@ TEST_F(SubscribeTest, SendCorrectRequest)
 }
 
 #endif // EWS_USE_BOOST_LIBRARY
-#endif


### PR DESCRIPTION
This pull request implements the [Notification operations](https://msdn.microsoft.com/en-us/library/office/bb409286(v=exchg.150).aspx#Anchor_9)  as wanted in #80 . 

Done:
- [\<Subscribe\> operation](https://msdn.microsoft.com/en-us/library/office/aa566188(v=exchg.150).aspx)
  - The `event_type` enum class has been added to correctly use all available `event_types`. At least one of these are mandatory per request according to EWS. 
  - The `subscription_information` struct contains the `subscription_id` and `watermark` which are needed for furhter use. This object is returned by the `subscribe` function.
  - Tests have been added as well to check the validity of the parsed information and the send request.

- [\<Unsubscribe\> operation](https://msdn.microsoft.com/en-us/library/office/aa564263(v=exchg.150).aspx)

- [\<GetEvents\> operation](https://msdn.microsoft.com/en-us/library/office/aa566199(v=exchg.150).aspx)

Not started:
- [\<GetStreamingEvents\>](https://msdn.microsoft.com/en-us/library/office/ff406172(v=exchg.150).aspx)