### PR TITLE
Paged search

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -16877,7 +16877,7 @@ private:
 };
 
 #ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
-static_assert(!std::is_default_constructible<paging_view>::value, "");
+static_assert(std::is_default_constructible<paging_view>::value, "");
 static_assert(std::is_copy_constructible<paging_view>::value, "");
 static_assert(std::is_copy_assignable<paging_view>::value, "");
 static_assert(std::is_move_constructible<paging_view>::value, "");

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -16819,6 +16819,11 @@ static_assert(std::is_move_assignable<contains>::value, "");
 class paging_view
 {
 public:
+	paging_view() : max_entries_returned_(1000), offset_(0),
+		base_point_(paging_base_point::beginning)
+	{
+	}
+
     paging_view(std::uint32_t max_entries_returned)
         : max_entries_returned_(max_entries_returned), offset_(0), 
           base_point_(paging_base_point::beginning)

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -5510,6 +5510,34 @@ namespace internal
     }
 }
 
+//! \brief Defines the base point for
+//! paged searches with <tt>\<FindItem\></tt>
+//! and <tt>\<FindFolder\></tt>.
+enum class paging_base_point
+{
+    //! The paged view starts at the beginning of the found conversation or item set.
+    beginning,
+
+    //! The paged view starts at the end of the found conversation or item set.
+    end
+};
+
+namespace internal
+{
+    inline std::string enum_to_str(paging_base_point base)
+    {
+        switch (base)
+        {
+        case paging_base_point::beginning:
+            return "Beginning";
+        case paging_base_point::end:
+            return "End";
+        default:
+            throw exception("Bad enum value");
+        }
+    }
+}
+
 //! \brief Defines the different values for the
 //! <tt>\<RequestServerVersion\></tt> element.
 enum class server_version
@@ -16785,6 +16813,72 @@ static_assert(std::is_move_constructible<contains>::value, "");
 static_assert(std::is_move_assignable<contains>::value, "");
 #endif
 
+//! \brief A paged view of items in a folder
+//!
+//! Represents a paged view of items in item search operations.
+class paging_view
+{
+public:
+    paging_view(std::uint32_t max_entries_returned)
+        : max_entries_returned_(max_entries_returned), offset_(0), 
+          base_point_(paging_base_point::beginning)
+    {
+    }
+
+    paging_view(std::uint32_t max_entries_returned, 
+        std::uint32_t offset)
+        : max_entries_returned_(max_entries_returned), offset_(offset),
+          base_point_(paging_base_point::beginning)
+    {
+    }
+
+    paging_view(std::uint32_t max_entries_returned,
+        std::uint32_t offset, 
+        paging_base_point base_point)
+        : max_entries_returned_(max_entries_returned), offset_(offset), 
+          base_point_(base_point)
+    {
+    }
+
+    std::uint32_t get_max_entries_returned() const EWS_NOEXCEPT
+    {
+        return max_entries_returned_;
+    }
+
+    std::uint32_t get_offset() const EWS_NOEXCEPT
+    {
+        return offset_;
+    }
+
+    std::string to_xml() const
+    {
+        return "<m:IndexedPageItemView MaxEntriesReturned=\"" +
+            std::to_string(max_entries_returned_) +
+            "\" Offset=\"" +
+            std::to_string(offset_) +
+            "\" BasePoint=\"" +
+            internal::enum_to_str(base_point_) + "\" />";
+    }
+
+    void advance()
+    {
+        offset_ += max_entries_returned_;
+    }
+
+private:
+    std::uint32_t max_entries_returned_;
+    std::uint32_t offset_;
+    paging_base_point base_point_;
+};
+
+#ifdef EWS_HAS_NON_BUGGY_TYPE_TRAITS
+static_assert(!std::is_default_constructible<paging_view>::value, "");
+static_assert(std::is_copy_constructible<paging_view>::value, "");
+static_assert(std::is_copy_assignable<paging_view>::value, "");
+static_assert(std::is_move_constructible<paging_view>::value, "");
+static_assert(std::is_move_assignable<paging_view>::value, "");
+#endif
+
 //! \brief A range view of appointments in a calendar.
 //!
 //! Represents a date range view of appointments in calendar folder search
@@ -17581,6 +17675,28 @@ public:
         {
             throw exchange_error(response_message.result());
         }
+    }
+
+    std::vector<item_id> find_item(const folder_id& parent_folder_id, const paging_view& view)
+    {
+        const std::string request_string =
+            "<m:FindItem Traversal=\"Shallow\">"
+            "<m:ItemShape>"
+            "<t:BaseShape>IdOnly</t:BaseShape>"
+            "</m:ItemShape>" +
+            view.to_xml() +
+            "<m:ParentFolderIds>" +
+            parent_folder_id.to_xml() +
+            "</m:ParentFolderIds>"
+            "</m:FindItem>";
+
+        auto response = request(request_string);
+        const auto response_message = internal::find_item_response_message::parse(std::move(response));
+        if (!response_message.success())
+        {
+            throw exchange_error(response_message.result());
+        }
+        return response_message.items();
     }
 
     std::vector<item_id> find_item(const folder_id& parent_folder_id)


### PR DESCRIPTION
My first time contributing a project on GitHub or using git, so bear with me.

Exchange is limiting the search results to 1000 due to the EWS throttling (https://msdn.microsoft.com/en-us/library/office/jj945066(v=exchg.150).aspx) defined in the EWSFindCountLimit value.
Using the paging search as specified here: https://msdn.microsoft.com/en-us/library/office/dn592093(v=exchg.150).aspx

I added an overload to the find_item(...) message of base_service. It gets a const ref to an object of the new class paging_view (based on the calendar_view class). This object defines the number of item IDs to return, the offset and the base point (which is basically the direction). Using the advance() public member function, the offset can be advanced between the subsequent calls of find_item(...).
The base point is defined as an enum class including an internal enum_to_string function.

This is the way that seems like it fits the concept of the library best. Especially since the calendar_view is basically implemented the same way. I was thinking about returning a more complex object from this overload of find_item(...) to return the additional information of the response (TotalItemsInView and IncludesLastItemInRange) but it would require modifying the response parser and would break the linear concept of find_item (returning a vector<item_id>).

I never used doxygen, so I'm not 100% on the comments but I think it should be correct. Maybe it would require a little more description on how the paging_view class works.

I haven't added any tests because I'm a little under pressured right now.

Any advice on contributing to the project is welcome. We will probably use this library for our system and will need a few features that are not yet implemented. So more PRs are ahead.