### PR TITLE
Remove gtest submodule -Werror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/gtest"]
+	path = 3rdparty/gtest
+	url = https://github.com/m-Schlitzer/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/gtest"]
-	path = 3rdparty/gtest
-	url = https://github.com/google/googletest.git


### PR DESCRIPTION
These commit change the gtest submodule to my fork, where I removed the -Werror flag causing some of our builds to fail.