### PR TITLE
Remove invalid EWS_ASSERT in get_folder_impl

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18564,7 +18564,6 @@ private:
                                          base_shape shape)
     {
         EWS_ASSERT(!ids.empty());
-        EWS_ASSERT(!additional_properties.empty());
 
         std::stringstream sstr;
         sstr << "<m:GetFolder>"


### PR DESCRIPTION
The overload of get_folder_impl without the additional_properties
parameter was checking said parameter.