### PR TITLE
Correctly initialize modified_event

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -9163,11 +9163,7 @@ private:
 class modified_event final : public internal::event_base
 {
 public:
-#ifdef EWS_HAS_DEFAULT_AND_DELETE
-    modified_event() = default;
-#else
-    modified_event() {}
-#endif
+    modified_event() : unread_count_(0) {}
 
     static modified_event from_xml_element(const rapidxml::xml_node<>& elem)
     {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -9174,7 +9174,7 @@ public:
         item_id id;
         folder_id f_id;
         folder_id parent_folder_id;
-        int unread_count;
+        int unread_count = 0;
         for (auto node = elem.first_node(); node; node = node->next_sibling())
         {
             if (compare(node->local_name(), node->local_name_size(),


### PR DESCRIPTION
Removes the warning produced by probably uninitialized unread_count_ member.