### PR TITLE
Fix travis ci gh-pages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
 deploy:
   provider: pages
   skip_cleanup: true
-  local_dir: "html"
+  local_dir: "build/html"
   github_token: "$GH_REPO_TOKEN"
   on:
     branch: master


### PR DESCRIPTION
The local_dir option was wrong, after the newest travis update it seems. https://github.com/travis-ci/travis-ci/issues/9047