### PR TITLE
Get rooms

### DIFF
--- a/examples/get_rooms.cpp
+++ b/examples/get_rooms.cpp
@@ -1,0 +1,72 @@
+
+//   Copyright 2018 otris software AG
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#include <ews/ews.hpp>
+#include <ews/ews_test_support.hpp>
+#include <exception>
+#include <iostream>
+#include <ostream>
+#include <stdlib.h>
+#include <string>
+
+int main()
+{
+    int res = EXIT_SUCCESS;
+    ews::set_up();
+
+    try
+    {
+        const auto env = ews::test::environment();
+        auto service = ews::service(env.server_uri, env.domain, env.username,
+                                    env.password);
+         
+        auto room_lists = service.get_room_lists();
+        if (room_lists.empty())
+        {
+            std::cout << "There are no room lists configured\n";
+        } 
+        else
+        {   
+            for (const auto& room_list : room_lists)
+            {
+                std::cout << "The room list " 
+                          << room_list.name()
+                          << " contains the following rooms:\n";
+                auto rooms = service.get_rooms(room_list);
+                if (rooms.empty())
+                {
+                    std::cout << "This room list does not contain any rooms\n";
+                }
+                else
+                {
+                    for (const auto& room : rooms)
+                    {
+                        std::cout << room.name() << "\n";
+                    }
+                }
+            }
+        }
+    }
+    catch (std::exception& exc)
+    {
+        std::cout << exc.what() << std::endl;
+        res = EXIT_FAILURE;
+    }
+
+    ews::tear_down();
+    return res;
+}
+
+// vim:et ts=4 sw=4

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18728,7 +18728,8 @@ public:
         std::string msg = "<m:GetRoomLists />";
         auto response = request(msg);
         const auto response_message =
-            internal::get_room_lists_response_message::parse(std::move(response));
+            internal::get_room_lists_response_message::parse(
+                std::move(response));
         if (!response_message.success())
         {
             throw exchange_error(response_message.result());


### PR DESCRIPTION
I added the get_room_lists() and get_rooms(const mailbox&) functions.
Those can be used to query the rooms that are configured on the exchange server.

First use get_room_lists to get a list of room lists in the form of mailbox objects.
Then use get_rooms for each of the room lists returned by get_room_lists.

According to various sources, it's not possible to just query all rooms with ews.
In fact, exchange works perfectly well with room when there is no room list configured.
OWA and Outlook will let the user pick one of the rooms for an appointment.
Nevertheless, it's not possible to query those rooms with ews. And it's not possible to create rooms or room lists either.

This makes it pretty difficult to write a test for those functions because the tests require pre-configuration. Not sure how you would handle this.

But I added an example though.