### PR TITLE
Remove boost

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,6 @@ before_build:
       cd C:\projects\ews-cpp
       mkdir build
       cd build
-      set BOOST_ROOT=C:\Libraries\boost_1_65_1
       cmake -G "Visual Studio 15 2017 Win64" -DCURL_INCLUDE_DIR="C:\projects\ews-cpp\scripts\win64\include" -DCURL_LIBRARY="C:\projects\ews-cpp\scripts\win64\lib\libcurl.lib" ..
 
 build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,15 @@ if(HAS_VARIANT)
     add_definitions(-DEWS_HAS_VARIANT)
 endif()
 
+# Test support for C++17 <filesystem> header
+CHECK_CXX_SOURCE_COMPILES("
+#include <filesystem>
+int main() { }
+" HAS_FILESYSTEM_HEADER)
+if(HAS_FILESYSTEM_HEADER)
+    add_definitions(-DEWS_HAS_FILESYSTEM_HEADER)
+endif()
+
 # Helper function for all those example executables
 function(add_example EXAMPLE_NAME)
     add_executable(${EXAMPLE_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,20 +169,6 @@ set(rapidxml_SOURCES
 find_package(CURL 7.29 REQUIRED)
 include_directories(${ews_INCLUDE_DIR} ${CURL_INCLUDE_DIRS})
 
-# Boost is optional as it is only used by some test cases
-if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
-    set(Boost_USE_STATIC_LIBS ON)
-else()
-    set(Boost_USE_STATIC_LIBS OFF)
-endif()
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.53 COMPONENTS system filesystem)
-if(Boost_FOUND)
-    add_definitions(-DEWS_USE_BOOST_LIBRARY -DBOOST_FILESYSTEM_NO_DEPRECATED)
-    include_directories(${Boost_INCLUDE_DIRS})
-endif()
-
 if(ENABLE_ASSERTS)
     add_definitions(-DEWS_ENABLE_ASSERTS)
 endif()
@@ -414,12 +400,7 @@ add_executable(tests
     ${rapidxml_SOURCES}
     ${ews_TESTS})
 
-if(Boost_FOUND)
-    target_link_libraries(tests ${GTEST_LIBRARIES} ${CURL_LIBRARIES}
-        ${Boost_LIBRARIES})
-else()
-    target_link_libraries(tests ${GTEST_LIBRARIES} ${CURL_LIBRARIES})
-endif()
+target_link_libraries(tests ${GTEST_LIBRARIES} ${CURL_LIBRARIES})
 set_target_properties(tests PROPERTIES
     LINKER_LANGUAGE CXX
     COMPILE_FLAGS "${SANITIZE_CXXFLAGS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ endif()
 # Test support for C++17 <filesystem> header
 CHECK_CXX_SOURCE_COMPILES("
 #include <filesystem>
-int main() { }
+int main() { std::filesystem::path p; }
 " HAS_FILESYSTEM_HEADER)
 if(HAS_FILESYSTEM_HEADER)
     add_definitions(-DEWS_HAS_FILESYSTEM_HEADER)
@@ -400,7 +400,11 @@ add_executable(tests
     ${rapidxml_SOURCES}
     ${ews_TESTS})
 
-target_link_libraries(tests ${GTEST_LIBRARIES} ${CURL_LIBRARIES})
+set(_libs ${GTEST_LIBRARIES} ${CURL_LIBRARIES})
+if(HAS_FILESYSTEM_HEADER AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(_libs ${_libs} stdc++fs)
+endif()
+target_link_libraries(tests ${_libs})
 set_target_properties(tests PROPERTIES
     LINKER_LANGUAGE CXX
     COMPILE_FLAGS "${SANITIZE_CXXFLAGS}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ def buildProject(String distro, String buildType) {
     sh """
     distribution=\$(lsb_release -is)
     distributionVersion=\$(lsb_release -rs)
-    
+
     if [ "\$distribution" = "Ubuntu" ]; then
         if [ "\$distributionVersion" = "16.04" ]; then
             sudo apt-get install -y \
@@ -15,18 +15,16 @@ def buildProject(String distro, String buildType) {
                 build-essential \
                 g++ \
                 libcurl4-openssl-dev \
-                libasan1 \
-                libboost-all-dev
+                libasan1
         fi
     fi
-    
+
     if [ "\$distribution" = "CentOS" ]; then
         sudo yum install -y \
             cmake \
             gcc-c++ \
             libcurl-devel \
-            libasan \
-            libboost-devel
+            libasan
     fi
     """
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ If you want to hack on ews-cpp itself you additionally need
 * Git
 * CMake
 * Doxygen (optional)
-* Boost (optional)
 * Python 2 or 3 (optional)
 
 ## Note Windows Users

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -8163,7 +8163,7 @@ public:
     //! \brief Creates a new undefined mailbox.
     //!
     //! Only useful as return value to indicate that no mailbox is set or
-    //! available. (Good candidate for {boost,std}::optional)
+    //! available. (Good candidate for std::optional)
     mailbox() = default;
 #else
     mailbox() {}

--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -27,8 +27,8 @@
 #include <utility>
 #include <vector>
 
-#ifdef EWS_USE_BOOST_LIBRARY
-#    include <boost/filesystem.hpp>
+#ifdef EWS_HAS_FILESYSTEM_HEADER
+#    include <filesystem>
 #    include <fstream>
 #    include <iostream>
 #    include <iterator>
@@ -52,9 +52,9 @@ inline bool contains_if(const ContainerType& cont, Predicate pred)
     return std::find_if(begin(cont), end(cont), pred) != end(cont);
 }
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 // Read file contents into a buffer
-inline std::vector<char> read_file(const boost::filesystem::path& path)
+inline std::vector<char> read_file(const std::filesystem::path& path)
 {
     std::ifstream ifstr(path.string(), std::ifstream::in | std::ios::binary);
     if (!ifstr.is_open())
@@ -79,7 +79,7 @@ inline std::vector<char> read_file(const boost::filesystem::path& path)
     contents.push_back('\0');
     return contents;
 }
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER
 
 // Allows you to test requests w/o sending anything to the server. See also
 // FakeServiceFixture.
@@ -415,22 +415,22 @@ private:
     ews::message message_;
 };
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 class ResolveNamesTest : public FakeServiceFixture
 {
 public:
-    const boost::filesystem::path assets_dir() const
+    const std::filesystem::path assets_dir() const
     {
-        return boost::filesystem::path(assets());
+        return std::filesystem::path(assets());
     }
 };
 
 class SubscribeTest : public FakeServiceFixture
 {
 public:
-    const boost::filesystem::path assets_dir() const
+    const std::filesystem::path assets_dir() const
     {
-        return boost::filesystem::path(assets());
+        return std::filesystem::path(assets());
     }
 };
 
@@ -441,36 +441,36 @@ public:
     {
         BaseFixture::SetUp();
 
-        olddir_ = boost::filesystem::current_path();
-        workingdir_ = boost::filesystem::unique_path(
-            boost::filesystem::temp_directory_path() / "%%%%-%%%%-%%%%-%%%%");
-        ASSERT_TRUE(boost::filesystem::create_directory(workingdir_))
+        olddir_ = std::filesystem::current_path();
+        workingdir_ = std::filesystem::unique_path(
+            std::filesystem::temp_directory_path() / "%%%%-%%%%-%%%%-%%%%");
+        ASSERT_TRUE(std::filesystem::create_directory(workingdir_))
             << "Unable to create temporary working directory";
-        boost::filesystem::current_path(workingdir_);
+        std::filesystem::current_path(workingdir_);
     }
 
     void TearDown()
     {
-        EXPECT_TRUE(boost::filesystem::is_empty(workingdir_))
+        EXPECT_TRUE(std::filesystem::is_empty(workingdir_))
             << "Temporary directory not empty on TearDown";
-        boost::filesystem::current_path(olddir_);
-        boost::filesystem::remove_all(workingdir_);
+        std::filesystem::current_path(olddir_);
+        std::filesystem::remove_all(workingdir_);
 
         BaseFixture::TearDown();
     }
 
-    const boost::filesystem::path& cwd() const { return workingdir_; }
+    const std::filesystem::path& cwd() const { return workingdir_; }
 
-    const boost::filesystem::path assets_dir() const
+    const std::filesystem::path assets_dir() const
     {
-        return boost::filesystem::path(assets());
+        return std::filesystem::path(assets());
     }
 
 private:
-    boost::filesystem::path olddir_;
-    boost::filesystem::path workingdir_;
+    std::filesystem::path olddir_;
+    std::filesystem::path workingdir_;
 };
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER
 
 inline ews::task make_fake_task(const char* xml = nullptr)
 {
@@ -542,7 +542,7 @@ inline ews::task make_fake_task(const char* xml = nullptr)
     return ews::task::from_xml_element(*node);
 }
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 inline ews::message make_fake_message(const char* xml = nullptr)
 {
     typedef rapidxml::xml_document<> xml_document;
@@ -560,7 +560,7 @@ inline ews::message make_fake_message(const char* xml = nullptr)
     {
         // Load from file
 
-        const auto assets = boost::filesystem::path(
+        const auto assets = std::filesystem::path(
             ews::test::global_data::instance().assets_dir);
         const auto file_path =
             assets / "undeliverable_test_mail_get_item_response.xml";
@@ -587,5 +587,5 @@ inline ews::message make_fake_message(const char* xml = nullptr)
         doc, "Message", ews::internal::uri<>::microsoft::types());
     return ews::message::from_xml_element(*node);
 }
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER
 } // namespace tests

--- a/tests/fixtures.hpp
+++ b/tests/fixtures.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #ifdef EWS_HAS_FILESYSTEM_HEADER
+#    include <cstdio>
 #    include <filesystem>
 #    include <fstream>
 #    include <iostream>
@@ -442,8 +443,7 @@ public:
         BaseFixture::SetUp();
 
         olddir_ = std::filesystem::current_path();
-        workingdir_ = std::filesystem::unique_path(
-            std::filesystem::temp_directory_path() / "%%%%-%%%%-%%%%-%%%%");
+        workingdir_ = std::tmpnam(nullptr);
         ASSERT_TRUE(std::filesystem::create_directory(workingdir_))
             << "Unable to create temporary working directory";
         std::filesystem::current_path(workingdir_);

--- a/tests/test_attachments.cpp
+++ b/tests/test_attachments.cpp
@@ -193,7 +193,7 @@ TEST_F(AttachmentTest, CreateAndDeleteItemAttachmentOnServer)
     EXPECT_STREQ("This message", attachments[0].name().c_str());
 }
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 class FileAttachmentTest : public TemporaryDirectoryFixture, public ServiceMixin
 {
 };
@@ -243,7 +243,7 @@ TEST_F(FileAttachmentTest, WriteContentToFileDoesNothingIfItemAttachment)
     const auto bytes_written =
         item_attachment.write_content_to_file(target_path.string());
     EXPECT_EQ(0U, bytes_written);
-    EXPECT_FALSE(boost::filesystem::exists(target_path));
+    EXPECT_FALSE(std::filesystem::exists(target_path));
 }
 
 TEST_F(FileAttachmentTest, WriteContentToFile)
@@ -263,9 +263,9 @@ TEST_F(FileAttachmentTest, WriteContentToFile)
     auto attachment = ews::attachment::from_xml_element(*node);
     const auto bytes_written =
         attachment.write_content_to_file(target_path.string());
-    on_scope_exit remove_file([&] { boost::filesystem::remove(target_path); });
+    on_scope_exit remove_file([&] { std::filesystem::remove(target_path); });
     EXPECT_EQ(93525U, bytes_written);
-    EXPECT_TRUE(boost::filesystem::exists(target_path));
+    EXPECT_TRUE(std::filesystem::exists(target_path));
 }
 
 TEST_F(FileAttachmentTest, WriteContentToFileThrowsOnEmptyFileName)
@@ -390,5 +390,5 @@ TEST_F(FileAttachmentTest, CreateAndDeleteFileAttachmentOnServer)
     EXPECT_THROW({ service().get_attachment(attachment_id); },
                  ews::exchange_error);
 }
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER
 } // namespace tests

--- a/tests/test_autodiscover.cpp
+++ b/tests/test_autodiscover.cpp
@@ -15,7 +15,7 @@
 //
 //   This project is hosted at https://github.com/otris
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 
 #    include "fixtures.hpp"
 
@@ -191,4 +191,4 @@ TEST_F(AutodiscoverTest, GetExchangeWebServicesURLExceptionText)
 }
 } // namespace tests
 
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER

--- a/tests/test_items.cpp
+++ b/tests/test_items.cpp
@@ -269,9 +269,6 @@ TEST(OfflineItemTest, GetAndSetBodyProperty)
 {
     auto item = ews::item();
 
-    // TODO: better: what to do!? EXPECT_FALSE(item.get_body().none());
-    // boost::optional desperately missing
-
     auto original = ews::body("<p>Some of the finest Vogon poetry</p>",
                               ews::body_type::html);
     item.set_body(original);
@@ -490,7 +487,7 @@ TEST(OfflineItemTest, IsUnmodifiedDefaultConstructed)
     EXPECT_FALSE(task.is_unmodified());
 }
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 TEST(OfflineItemTest, GetInternetMessageHeaders)
 {
     auto message = make_fake_message();
@@ -553,7 +550,7 @@ TEST(OfflineItemTest, GetInternetMessageHeaders)
         expected++;
     }
 }
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER
 
 TEST(OfflineItemTest, GetDateTimeSentProperty)
 {

--- a/tests/test_resolve_names.cpp
+++ b/tests/test_resolve_names.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 namespace tests
 {
 TEST_F(ResolveNamesTest, NoUserFound)
@@ -59,4 +59,4 @@ TEST_F(ResolveNamesTest, SendCorrectRequest)
 }
 } // namespace tests
 
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER

--- a/tests/test_service.cpp
+++ b/tests/test_service.cpp
@@ -24,7 +24,7 @@
 #include <stdexcept>
 #include <utility>
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 #    include <boost/filesystem.hpp>
 #endif
 
@@ -33,7 +33,7 @@ using ews::internal::on_scope_exit;
 namespace tests
 {
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 class GetItemRequestTest : public FakeServiceFixture
 {
 private:
@@ -41,7 +41,7 @@ private:
     {
         FakeServiceFixture::SetUp();
 
-        const auto assets = boost::filesystem::path(
+        const auto assets = std::filesystem::path(
             ews::test::global_data::instance().assets_dir);
         const auto file_path = assets / "get_item_response_message.xml";
         std::ifstream ifstr(file_path.string(),
@@ -84,7 +84,7 @@ TEST_F(GetItemRequestTest, WithAdditionalProperties)
                   "</t:AdditionalProperties>"),
               std::string::npos);
 }
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER
 
 class SoapHeader : public FakeServiceFixture
 {

--- a/tests/test_service.cpp
+++ b/tests/test_service.cpp
@@ -24,10 +24,6 @@
 #include <stdexcept>
 #include <utility>
 
-#ifdef EWS_HAS_FILESYSTEM_HEADER
-#    include <boost/filesystem.hpp>
-#endif
-
 using ews::internal::on_scope_exit;
 
 namespace tests

--- a/tests/test_subscribe.cpp
+++ b/tests/test_subscribe.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#ifdef EWS_USE_BOOST_LIBRARY
+#ifdef EWS_HAS_FILESYSTEM_HEADER
 namespace tests
 {
 TEST_F(SubscribeTest, SubscriptionSuccessful)
@@ -61,4 +61,4 @@ TEST_F(SubscribeTest, SendCorrectRequest)
 }
 } // namespace tests
 
-#endif // EWS_USE_BOOST_LIBRARY
+#endif // EWS_HAS_FILESYSTEM_HEADER


### PR DESCRIPTION
Remove Boost.Filesystem dependency

Use std::filesystem instead. Since most compilers and development environments already support C++17 std::filesystem it doesn't make sense to require an extra-heavy dependency like Boost anymore for running some additional tests.