### PR TITLE
More careful response parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ message(STATUS "Git SHA-1: ${GIT_SHA1}")
 
 include(CheckCXXCompilerFlag)
 
-option(ENABLE_ASSERTS "Enable run-time checks." OFF)
 option(DISABLE_TLS_CERT_VERIFICATION
     "Turn-off verification of the server's authenticity." OFF)
 if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
@@ -168,10 +167,6 @@ set(rapidxml_SOURCES
 # libcurl 7.35 is packed for Ubuntu 14.04 LTS, 7.29 for RHEL7
 find_package(CURL 7.29 REQUIRED)
 include_directories(${ews_INCLUDE_DIR} ${CURL_INCLUDE_DIRS})
-
-if(ENABLE_ASSERTS)
-    add_definitions(-DEWS_ENABLE_ASSERTS)
-endif()
 
 if(DISABLE_TLS_CERT_VERIFICATION)
     add_definitions(-DEWS_DISABLE_TLS_CERT_VERIFICATION)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ def buildProject(String distro, String buildType) {
     withCredentials([usernamePassword(credentialsId: 'c0ede5c0-82be-4ff0-b618-39aeddcdfaba', passwordVariable: 'password', usernameVariable: 'username')]) {
       dir('build') {
         sh """
-        cmake -DCMAKE_BUILD_TYPE=${buildType} -DENABLE_ASAN=ON -DENABLE_ASSERTS=OFF -DDISABLE_TLS_CERT_VERIFICATION=ON ..
+        cmake -DCMAKE_BUILD_TYPE=${buildType} -DENABLE_ASAN=ON -DDISABLE_TLS_CERT_VERIFICATION=ON ..
         make -j2
 
         EWS_TEST_URI=https://duckburg.otris.de/ews/Exchange.asmx \

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -10572,9 +10572,9 @@ namespace internal
             const auto doc = parse_response(std::move(response));
             auto elem = get_element_by_qname(*doc, "DeleteItemResponseMessage",
                                              uri<>::microsoft::messages());
-            auto result = parse_response_class_and_code(*elem);
             EWS_ASSERT(elem,
                        "Expected <DeleteItemResponseMessage>, got nullptr");
+            auto result = parse_response_class_and_code(*elem);
             return delete_item_response_message(std::move(result));
         }
 

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -10433,9 +10433,7 @@ namespace internal
                 get_element_by_qname(*doc, "CreateAttachmentResponseMessage",
                                      uri<>::microsoft::messages());
 
-            EWS_ASSERT(
-                elem,
-                "Expected <CreateAttachmentResponseMessage>, got nullptr");
+            EWS_ASSERT(elem, "Expected <CreateAttachmentResponseMessage>");
 
             auto result = parse_response_class_and_code(*elem);
 
@@ -10485,8 +10483,7 @@ namespace internal
                 get_element_by_qname(*doc, "GetAttachmentResponseMessage",
                                      uri<>::microsoft::messages());
 
-            EWS_ASSERT(elem,
-                       "Expected <GetAttachmentResponseMessage>, got nullptr");
+            EWS_ASSERT(elem, "Expected <GetAttachmentResponseMessage>");
 
             auto result = parse_response_class_and_code(*elem);
 
@@ -10530,7 +10527,7 @@ namespace internal
             auto elem = get_element_by_qname(*doc, "SendItemResponseMessage",
                                              uri<>::microsoft::messages());
 
-            EWS_ASSERT(elem, "Expected <SendItemResponseMessage>, got nullptr");
+            EWS_ASSERT(elem, "Expected <SendItemResponseMessage>");
             auto result = parse_response_class_and_code(*elem);
             return send_item_response_message(std::move(result));
         }
@@ -10552,8 +10549,7 @@ namespace internal
                 get_element_by_qname(*doc, "DeleteFolderResponseMessage",
                                      uri<>::microsoft::messages());
             auto result = parse_response_class_and_code(*elem);
-            EWS_ASSERT(elem,
-                       "Expected <DeleteFolderResponseMessage>, got nullptr");
+            EWS_ASSERT(elem, "Expected <DeleteFolderResponseMessage>");
             return delete_folder_response_message(std::move(result));
         }
 
@@ -10572,8 +10568,7 @@ namespace internal
             const auto doc = parse_response(std::move(response));
             auto elem = get_element_by_qname(*doc, "DeleteItemResponseMessage",
                                              uri<>::microsoft::messages());
-            EWS_ASSERT(elem,
-                       "Expected <DeleteItemResponseMessage>, got nullptr");
+            EWS_ASSERT(elem, "Expected <DeleteItemResponseMessage>");
             auto result = parse_response_class_and_code(*elem);
             return delete_item_response_message(std::move(result));
         }
@@ -10597,9 +10592,7 @@ namespace internal
                 get_element_by_qname(*doc, "DeleteAttachmentResponseMessage",
                                      uri<>::microsoft::messages());
 
-            EWS_ASSERT(
-                elem,
-                "Expected <DeleteAttachmentResponseMessage>, got nullptr");
+            EWS_ASSERT(elem, "Expected <DeleteAttachmentResponseMessage>");
             auto result = parse_response_class_and_code(*elem);
 
             auto root_item_id = item_id();
@@ -20720,7 +20713,7 @@ sync_folder_items_result::parse(internal::http_response&& response)
         internal::get_element_by_qname(*doc, "SyncFolderItemsResponseMessage",
                                        internal::uri<>::microsoft::messages());
 
-    EWS_ASSERT(elem, "Expected <SyncFolderItemsResponseMessage>, got nullptr");
+    EWS_ASSERT(elem, "Expected <SyncFolderItemsResponseMessage>");
     auto result = internal::parse_response_class_and_code(*elem);
     if (result.cls == response_class::error)
     {
@@ -20824,7 +20817,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "CreateFolderResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <CreateFolderResponseMessage>, got nullptr");
+        EWS_ASSERT(elem, "Expected <CreateFolderResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
         auto item_ids = std::vector<folder_id>();
         auto items_elem =
@@ -20849,7 +20842,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "CreateItemResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <CreateItemResponseMessage>, got nullptr");
+        EWS_ASSERT(elem, "Expected <CreateItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
         auto item_ids = std::vector<item_id>();
         auto items_elem =
@@ -20873,7 +20866,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "FindFolderResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <FindFolderResponseMessage>, got nullptr");
+        EWS_ASSERT(elem, "Expected <FindFolderResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
 
         auto root_folder =
@@ -20888,7 +20881,7 @@ namespace internal
              item_elem = item_elem->next_sibling())
         {
             // TODO: Check that item is 'FolderId'
-            EWS_ASSERT(item_elem, "Expected an element, got nullptr");
+            EWS_ASSERT(item_elem, "Expected an element");
             auto item_id_elem = item_elem->first_node();
             EWS_ASSERT(item_id_elem, "Expected <FolderId> element");
             items.emplace_back(folder_id::from_xml_element(*item_id_elem));
@@ -20904,7 +20897,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "FindItemResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <FindItemResponseMessage>, got nullptr");
+        EWS_ASSERT(elem, "Expected <FindItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
 
         auto root_folder =
@@ -20918,7 +20911,7 @@ namespace internal
         for (auto item_elem = items_elem->first_node(); item_elem;
              item_elem = item_elem->next_sibling())
         {
-            EWS_ASSERT(item_elem, "Expected an element, got nullptr");
+            EWS_ASSERT(item_elem, "Expected an element");
             auto item_id_elem = item_elem->first_node();
             EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
             items.emplace_back(item_id::from_xml_element(*item_id_elem));
@@ -20933,7 +20926,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "FindItemResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <FindItemResponseMessage>, got nullptr");
+        EWS_ASSERT(elem, "Expected <FindItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
 
         auto root_folder =
@@ -20959,7 +20952,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "UpdateItemResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <UpdateItemResponseMessage>, got nullptr");
+        EWS_ASSERT(elem, "Expected <UpdateItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
 
         auto items_elem =
@@ -20970,7 +20963,7 @@ namespace internal
         for (auto item_elem = items_elem->first_node(); item_elem;
              item_elem = item_elem->next_sibling())
         {
-            EWS_ASSERT(item_elem, "Expected an element, got nullptr");
+            EWS_ASSERT(item_elem, "Expected an element");
             auto item_id_elem = item_elem->first_node();
             EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
             items.emplace_back(item_id::from_xml_element(*item_id_elem));
@@ -20985,7 +20978,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto elem = get_element_by_qname(*doc, "GetFolderResponseMessage",
                                          uri<>::microsoft::messages());
-        EWS_ASSERT(elem, "Expected <GetFolderResponseMessage>, got nullptr");
+        EWS_ASSERT(elem, "Expected <GetFolderResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "Folders");
@@ -21005,7 +20998,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "GetRoomListsResponse",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <GetRoomListsResponse>, got nullptr");
+        EWS_ASSERT(elem, "Expected <GetRoomListsResponse>");
         auto result = parse_response_class_and_code(*elem);
         auto room_lists = std::vector<mailbox>();
         auto items_elem =
@@ -21027,7 +21020,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "GetRoomsResponse",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <GetRoomsResponse>, got nullptr");
+        EWS_ASSERT(elem, "Expected <GetRoomsResponse>");
         auto result = parse_response_class_and_code(*elem);
         auto rooms = std::vector<mailbox>();
         auto items_elem =
@@ -21055,8 +21048,7 @@ namespace internal
 
         auto response_messages = get_element_by_qname(
             *doc, "ResponseMessages", uri<>::microsoft::messages());
-        EWS_ASSERT(response_messages,
-                   "Expected <ResponseMessages> node, got nullptr");
+        EWS_ASSERT(response_messages, "Expected <ResponseMessages> node");
 
         std::vector<folder_response_message::response_message> messages;
         for_each_child_node(
@@ -21088,7 +21080,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto elem = get_element_by_qname(*doc, "GetItemResponseMessage",
                                          uri<>::microsoft::messages());
-        EWS_ASSERT(elem, "Expected <GetItemResponseMessage>, got nullptr");
+        EWS_ASSERT(elem, "Expected <GetItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "Items");
@@ -21109,8 +21101,7 @@ namespace internal
 
         auto response_messages = get_element_by_qname(
             *doc, "ResponseMessages", uri<>::microsoft::messages());
-        EWS_ASSERT(response_messages,
-                   "Expected <ResponseMessages> node, got nullptr");
+        EWS_ASSERT(response_messages, "Expected <ResponseMessages> node");
 
         std::vector<item_response_messages::response_message> messages;
         for_each_child_node(
@@ -21174,8 +21165,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(*doc, "AddDelegateResponse",
                                                   uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem,
-                   "Expected <AddDelegateResponse>, got nullptr");
+        EWS_ASSERT(response_elem, "Expected <AddDelegateResponse>");
         auto result = parse_response_class_and_code(*response_elem);
 
         std::vector<delegate_user> delegates;
@@ -21193,8 +21183,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(*doc, "GetDelegateResponse",
                                                   uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem,
-                   "Expected <GetDelegateResponse>, got nullptr");
+        EWS_ASSERT(response_elem, "Expected <GetDelegateResponse>");
         auto result = parse_response_class_and_code(*response_elem);
 
         std::vector<delegate_user> delegates;
@@ -21212,7 +21201,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto resp = get_element_by_qname(*doc, "RemoveDelegateResponse",
                                          uri<>::microsoft::messages());
-        EWS_ASSERT(resp, "Expected <RemoveDelegateResponse>, got nullptr");
+        EWS_ASSERT(resp, "Expected <RemoveDelegateResponse>");
 
         auto result = parse_response_class_and_code(*resp);
         if (result.code == response_code::no_error)
@@ -21278,8 +21267,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(
             *doc, "ResolveNamesResponseMessage", uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem,
-                   "Expected <ResolveNamesResponseMessage>, got nullptr");
+        EWS_ASSERT(response_elem, "Expected <ResolveNamesResponseMessage>");
         auto result = parse_response_class_and_code(*response_elem);
 
         resolution_set resolutions;
@@ -21387,8 +21375,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(
             *doc, "SubscribeResponseMessage", uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem,
-                   "Expected <SubscribeResponseMessage>, got nullptr");
+        EWS_ASSERT(response_elem, "Expected <SubscribeResponseMessage>");
         auto result = parse_response_class_and_code(*response_elem);
 
         std::string id;
@@ -21417,8 +21404,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(
             *doc, "UnsubscribeResponseMessage", uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem,
-                   "Expected <UnsubscribeResponseMessage>, got nullptr");
+        EWS_ASSERT(response_elem, "Expected <UnsubscribeResponseMessage>");
         auto result = parse_response_class_and_code(*response_elem);
 
         return unsubscribe_response_message(std::move(result));
@@ -21431,8 +21417,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(
             *doc, "GetEventsResponseMessage", uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem,
-                   "Expected <GetEventsResponseMessage>, got nullptr");
+        EWS_ASSERT(response_elem, "Expected <GetEventsResponseMessage>");
         auto result = parse_response_class_and_code(*response_elem);
 
         notification n;

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -22069,3 +22069,5 @@ recurrence_range::from_xml_element(const rapidxml::xml_node<>& elem)
     return std::unique_ptr<recurrence_range>();
 }
 } // namespace ews
+
+#undef EWS_ASSERT

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -57,15 +57,21 @@
 
 #include "ews_fwd.hpp"
 
-#define EWS_ASSERT(expr, msg)                                                  \
-    if (!(expr))                                                               \
-    {                                                                          \
-        throw assertion_error(msg);                                            \
-    }
-
 //! Contains all classes, functions, and enumerations of this library
 namespace ews
 {
+
+#ifndef EWS_DOXYGEN_SHOULD_SKIP_THIS
+template <typename ExceptionType = ews::assertion_error>
+inline void check(bool expr, const char* msg)
+{
+    if (!expr)
+    {
+        throw ExceptionType(msg);
+    }
+}
+#endif
+
 namespace internal
 {
     // Scope guard helper.
@@ -477,7 +483,7 @@ private:
 
         const auto start = std::max(at - (columns / 2), static_cast<size_t>(0));
         const auto end = std::min(at + (columns / 2), str.length());
-        EWS_ASSERT((start < end), "Expected start to be before end");
+        check((start < end), "Expected start to be before end");
         std::string line;
         std::copy(&str[start], &str[end], std::back_inserter(line));
         const auto line_index = columns / 2;
@@ -6818,7 +6824,7 @@ namespace internal
         http_response(long code, std::vector<char>&& data)
             : data_(std::move(data)), code_(code)
         {
-            EWS_ASSERT(!data_.empty(), "Given data should not be empty");
+            check(!data_.empty(), "Given data should not be empty");
         }
 
 #ifdef EWS_HAS_DEFAULT_AND_DELETE
@@ -6927,7 +6933,7 @@ namespace internal
                                              const std::string& name)
     {
         auto doc = parent.document();
-        EWS_ASSERT(doc, "Parent node needs to be part of a document");
+        check(doc, "Parent node needs to be part of a document");
         auto ptr_to_qname = doc->allocate_string(name.c_str());
         auto new_node = doc->allocate_node(rapidxml::node_element);
         new_node->qname(ptr_to_qname, name.length(), ptr_to_qname + 2);
@@ -6942,7 +6948,7 @@ namespace internal
                                              const std::string& value)
     {
         auto doc = parent.document();
-        EWS_ASSERT(doc, "Parent node needs to be part of a document");
+        check(doc, "Parent node needs to be part of a document");
         auto str = doc->allocate_string(value.c_str());
         auto& new_node = create_node(parent, name);
         new_node.value(str);
@@ -6983,8 +6989,8 @@ namespace internal
     get_element_by_qname(const rapidxml::xml_node<>& node,
                          const char* local_name, const char* namespace_uri)
     {
-        EWS_ASSERT(local_name, "Expected local_name, got nullptr");
-        EWS_ASSERT(namespace_uri, "Expected namespace_uri, got nullptr");
+        check(local_name, "Expected local_name, got nullptr");
+        check(namespace_uri, "Expected namespace_uri, got nullptr");
 
         rapidxml::xml_node<>* element = nullptr;
         const auto local_name_len = strlen(local_name);
@@ -7556,8 +7562,8 @@ namespace internal
         deep_copy(rapidxml::xml_document<>* target_doc,
                   const rapidxml::xml_node<>* source)
         {
-            EWS_ASSERT(target_doc, "Expected target_doc, got nullptr");
-            EWS_ASSERT(source, "Expected source, got nullptr");
+            check(target_doc, "Expected target_doc, got nullptr");
+            check(source, "Expected source, got nullptr");
 
             auto newnode = target_doc->allocate_node(source->type());
 
@@ -7928,10 +7934,10 @@ public:
     static item_id from_xml_element(const rapidxml::xml_node<>& elem)
     {
         auto id_attr = elem.first_attribute("Id");
-        EWS_ASSERT(id_attr, "Missing attribute Id in <ItemId>");
+        check(id_attr, "Missing attribute Id in <ItemId>");
         auto id = std::string(id_attr->value(), id_attr->value_size());
         auto ckey_attr = elem.first_attribute("ChangeKey");
-        EWS_ASSERT(ckey_attr, "Missing attribute ChangeKey in <ItemId>");
+        check(ckey_attr, "Missing attribute ChangeKey in <ItemId>");
         auto ckey = std::string(ckey_attr->value(), ckey_attr->value_size());
         return item_id(std::move(id), std::move(ckey));
     }
@@ -8021,18 +8027,17 @@ public:
     static occurrence_item_id from_xml_element(const rapidxml::xml_node<>& elem)
     {
         auto id_attr = elem.first_attribute("RecurringMasterId");
-        EWS_ASSERT(id_attr,
-                   "Missing attribute RecurringMasterId in <OccurrenceItemId>");
+        check(id_attr,
+              "Missing attribute RecurringMasterId in <OccurrenceItemId>");
         auto id = std::string(id_attr->value(), id_attr->value_size());
 
         auto ckey_attr = elem.first_attribute("ChangeKey");
-        EWS_ASSERT(ckey_attr,
-                   "Missing attribute ChangeKey in <OccurrenceItemId>");
+        check(ckey_attr, "Missing attribute ChangeKey in <OccurrenceItemId>");
         auto ckey = std::string(ckey_attr->value(), ckey_attr->value_size());
 
         auto index_attr = elem.first_attribute("InstanceIndex");
-        EWS_ASSERT(index_attr,
-                   "Missing attribute InstanceIndex in <OccurrenceItemId>");
+        check(index_attr,
+              "Missing attribute InstanceIndex in <OccurrenceItemId>");
         auto index = std::stoi(
             std::string(index_attr->value(), index_attr->value_size()));
 
@@ -8112,7 +8117,7 @@ public:
     static attachment_id from_xml_element(const rapidxml::xml_node<>& elem)
     {
         auto id_attr = elem.first_attribute("Id");
-        EWS_ASSERT(id_attr, "Missing attribute Id in <AttachmentId>");
+        check(id_attr, "Missing attribute Id in <AttachmentId>");
         auto id = std::string(id_attr->value(), id_attr->value_size());
         auto root_item_id = std::string();
         auto root_item_ckey = std::string();
@@ -8124,8 +8129,8 @@ public:
                                        root_item_id_attr->value_size());
             auto root_item_ckey_attr =
                 elem.first_attribute("RootItemChangeKey");
-            EWS_ASSERT(root_item_ckey_attr,
-                       "Expected attribute 'RootItemChangeKey'");
+            check(root_item_ckey_attr,
+                  "Expected attribute 'RootItemChangeKey'");
             root_item_ckey = std::string(root_item_ckey_attr->value(),
                                          root_item_ckey_attr->value_size());
         }
@@ -8263,15 +8268,15 @@ public:
     {
         auto doc = parent.document();
 
-        EWS_ASSERT(doc, "Parent node needs to be somewhere in a document");
+        check(doc, "Parent node needs to be somewhere in a document");
 
         using namespace internal;
         auto& mailbox_node = create_node(parent, "t:Mailbox");
 
         if (!id_.valid())
         {
-            EWS_ASSERT(!value_.empty(),
-                       "Neither item_id nor value set in mailbox instance");
+            check(!value_.empty(),
+                  "Neither item_id nor value set in mailbox instance");
 
             create_node(mailbox_node, "t:EmailAddress", value_);
 
@@ -8366,8 +8371,8 @@ public:
 
         if (!id.valid())
         {
-            EWS_ASSERT(!address.empty(),
-                       "<EmailAddress> element value can't be empty");
+            check(!address.empty(),
+                  "<EmailAddress> element value can't be empty");
 
             return mailbox(std::move(address), std::move(name),
                            std::move(routing_type), std::move(mailbox_type));
@@ -8537,8 +8542,7 @@ public:
     static folder_id from_xml_element(const rapidxml::xml_node<>& elem)
     {
         auto id_attr = elem.first_attribute("Id");
-        EWS_ASSERT(id_attr,
-                   "Expected <ParentFolderId> to have an Id attribute");
+        check(id_attr, "Expected <ParentFolderId> to have an Id attribute");
         auto id = std::string(id_attr->value(), id_attr->value_size());
 
         std::string change_key;
@@ -9737,9 +9741,8 @@ public:
     {
         const auto elem_name =
             std::string(elem.local_name(), elem.local_name_size());
-        EWS_ASSERT(
-            (elem_name == "FileAttachment" || elem_name == "ItemAttachment"),
-            "Expected <FileAttachment> or <ItemAttachment>");
+        check((elem_name == "FileAttachment" || elem_name == "ItemAttachment"),
+              "Expected <FileAttachment> or <ItemAttachment>");
         return attachment(elem_name == "FileAttachment" ? type::file
                                                         : type::item,
                           internal::xml_subtree(elem));
@@ -9915,7 +9918,7 @@ namespace internal
         {
             auto response_code_elem = elem.first_node_ns(
                 uri<>::microsoft::messages(), "ResponseCode");
-            EWS_ASSERT(response_code_elem, "Expected <ResponseCode> element");
+            check(response_code_elem, "Expected <ResponseCode> element");
             code = str_to_response_code(response_code_elem->value());
 
             auto message_text_elem =
@@ -10433,13 +10436,13 @@ namespace internal
                 get_element_by_qname(*doc, "CreateAttachmentResponseMessage",
                                      uri<>::microsoft::messages());
 
-            EWS_ASSERT(elem, "Expected <CreateAttachmentResponseMessage>");
+            check(elem, "Expected <CreateAttachmentResponseMessage>");
 
             auto result = parse_response_class_and_code(*elem);
 
             auto attachments_element = elem->first_node_ns(
                 uri<>::microsoft::messages(), "Attachments");
-            EWS_ASSERT(attachments_element, "Expected <Attachments> element");
+            check(attachments_element, "Expected <Attachments> element");
 
             auto ids = std::vector<attachment_id>();
             for (auto attachment_elem = attachments_element->first_node();
@@ -10448,8 +10451,8 @@ namespace internal
             {
                 auto attachment_id_elem = attachment_elem->first_node_ns(
                     uri<>::microsoft::types(), "AttachmentId");
-                EWS_ASSERT(attachment_id_elem,
-                           "Expected <AttachmentId> in response");
+                check(attachment_id_elem,
+                      "Expected <AttachmentId> in response");
                 ids.emplace_back(
                     attachment_id::from_xml_element(*attachment_id_elem));
             }
@@ -10483,13 +10486,13 @@ namespace internal
                 get_element_by_qname(*doc, "GetAttachmentResponseMessage",
                                      uri<>::microsoft::messages());
 
-            EWS_ASSERT(elem, "Expected <GetAttachmentResponseMessage>");
+            check(elem, "Expected <GetAttachmentResponseMessage>");
 
             auto result = parse_response_class_and_code(*elem);
 
             auto attachments_element = elem->first_node_ns(
                 uri<>::microsoft::messages(), "Attachments");
-            EWS_ASSERT(attachments_element, "Expected <Attachments> element");
+            check(attachments_element, "Expected <Attachments> element");
             auto attachments = std::vector<attachment>();
             for (auto attachment_elem = attachments_element->first_node();
                  attachment_elem;
@@ -10527,7 +10530,7 @@ namespace internal
             auto elem = get_element_by_qname(*doc, "SendItemResponseMessage",
                                              uri<>::microsoft::messages());
 
-            EWS_ASSERT(elem, "Expected <SendItemResponseMessage>");
+            check(elem, "Expected <SendItemResponseMessage>");
             auto result = parse_response_class_and_code(*elem);
             return send_item_response_message(std::move(result));
         }
@@ -10549,7 +10552,7 @@ namespace internal
                 get_element_by_qname(*doc, "DeleteFolderResponseMessage",
                                      uri<>::microsoft::messages());
             auto result = parse_response_class_and_code(*elem);
-            EWS_ASSERT(elem, "Expected <DeleteFolderResponseMessage>");
+            check(elem, "Expected <DeleteFolderResponseMessage>");
             return delete_folder_response_message(std::move(result));
         }
 
@@ -10568,7 +10571,7 @@ namespace internal
             const auto doc = parse_response(std::move(response));
             auto elem = get_element_by_qname(*doc, "DeleteItemResponseMessage",
                                              uri<>::microsoft::messages());
-            EWS_ASSERT(elem, "Expected <DeleteItemResponseMessage>");
+            check(elem, "Expected <DeleteItemResponseMessage>");
             auto result = parse_response_class_and_code(*elem);
             return delete_item_response_message(std::move(result));
         }
@@ -10592,7 +10595,7 @@ namespace internal
                 get_element_by_qname(*doc, "DeleteAttachmentResponseMessage",
                                      uri<>::microsoft::messages());
 
-            EWS_ASSERT(elem, "Expected <DeleteAttachmentResponseMessage>");
+            check(elem, "Expected <DeleteAttachmentResponseMessage>");
             auto result = parse_response_class_and_code(*elem);
 
             auto root_item_id = item_id();
@@ -10601,13 +10604,12 @@ namespace internal
             if (root_item_id_elem)
             {
                 auto id_attr = root_item_id_elem->first_attribute("RootItemId");
-                EWS_ASSERT(id_attr, "Expected RootItemId attribute");
+                check(id_attr, "Expected RootItemId attribute");
                 auto id = std::string(id_attr->value(), id_attr->value_size());
 
                 auto change_key_attr =
                     root_item_id_elem->first_attribute("RootItemChangeKey");
-                EWS_ASSERT(change_key_attr,
-                           "Expected RootItemChangeKey attribute");
+                check(change_key_attr, "Expected RootItemChangeKey attribute");
                 auto change_key = std::string(change_key_attr->value(),
                                               change_key_attr->value_size());
 
@@ -11200,8 +11202,8 @@ public:
     //! Returns a reference to the newly created element.
     rapidxml::xml_node<>& to_xml_element(rapidxml::xml_node<>& parent) const
     {
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be somewhere in a document");
+        check(parent.document(),
+              "Parent node needs to be somewhere in a document");
 
         //  <Attendee>
         //    <Mailbox/>
@@ -11502,9 +11504,9 @@ public:
     {
         using rapidxml::internal::compare;
 
-        EWS_ASSERT(compare(elem.name(), elem.name_size(), "t:ExtendedFieldURI",
-                           strlen("t:ExtendedFieldURI")),
-                   "Expected a <ExtendedFieldURI>, got something else");
+        check(compare(elem.name(), elem.name_size(), "t:ExtendedFieldURI",
+                      strlen("t:ExtendedFieldURI")),
+              "Expected a <ExtendedFieldURI>, got something else");
 
         std::string distinguished_set_id;
         std::string set_id;
@@ -11554,7 +11556,7 @@ public:
             }
         }
 
-        EWS_ASSERT(!type.empty(), "'PropertyType' attribute missing");
+        check(!type.empty(), "'PropertyType' attribute missing");
 
         if (!distinguished_set_id.empty())
         {
@@ -11798,7 +11800,7 @@ public:
     {
         auto id_node =
             elem.first_node_ns(internal::uri<>::microsoft::types(), "FolderId");
-        EWS_ASSERT(id_node, "Expected <FolderId>");
+        check(id_node, "Expected <FolderId>");
         return folder(folder_id::from_xml_element(*id_node),
                       internal::xml_subtree(elem));
     }
@@ -11860,8 +11862,7 @@ public:
             return mime_content();
         }
         auto charset = node->first_attribute("CharacterSet");
-        EWS_ASSERT(charset,
-                   "Expected <MimeContent> to have CharacterSet attribute");
+        check(charset, "Expected <MimeContent> to have CharacterSet attribute");
         return mime_content(charset->value(), node->value(),
                             node->value_size());
     }
@@ -11970,8 +11971,7 @@ public:
                     }
                     else
                     {
-                        EWS_ASSERT(false,
-                                   "Unexpected attribute value for BodyType");
+                        check(false, "Unexpected attribute value for BodyType");
                     }
                 }
                 else if (compare(attr->name(), attr->name_size(), "IsTruncated",
@@ -11983,7 +11983,7 @@ public:
                 }
                 else
                 {
-                    EWS_ASSERT(false, "Unexpected attribute in <Body> element");
+                    check(false, "Unexpected attribute in <Body> element");
                 }
             }
 
@@ -13619,7 +13619,7 @@ public:
     {
         auto id_node =
             elem.first_node_ns(internal::uri<>::microsoft::types(), "ItemId");
-        EWS_ASSERT(id_node, "Expected <ItemId>");
+        check(id_node, "Expected <ItemId>");
         return task(item_id::from_xml_element(*id_node),
                     internal::xml_subtree(elem));
     }
@@ -13827,11 +13827,11 @@ email_address::from_xml_element(const rapidxml::xml_node<char>& node)
     //  <Entry Key="EmailAddress3">dragonmaster1999@yahoo.com</Entry>
     // </t:EmailAddresses>
 
-    EWS_ASSERT(compare(node.local_name(), node.local_name_size(), "Entry",
-                       strlen("Entry")),
-               "Expected <Entry> element");
+    check(compare(node.local_name(), node.local_name_size(), "Entry",
+                  strlen("Entry")),
+          "Expected <Entry> element");
     auto key = node.first_attribute("Key");
-    EWS_ASSERT(key, "Expected attribute 'Key'");
+    check(key, "Expected attribute 'Key'");
     return email_address(
         str_to_email_address_key(std::string(key->value(), key->value_size())),
         std::string(node.value(), node.value_size()));
@@ -13958,9 +13958,9 @@ physical_address::from_xml_element(const rapidxml::xml_node<char>& node)
     using namespace internal;
     using rapidxml::internal::compare;
 
-    EWS_ASSERT(compare(node.local_name(), node.local_name_size(), "Entry",
-                       strlen("Entry")),
-               "Expected <Entry>, got something else");
+    check(compare(node.local_name(), node.local_name_size(), "Entry",
+                  strlen("Entry")),
+          "Expected <Entry>, got something else");
 
     // <Entry Key="Home">
     //      <Street>
@@ -13971,9 +13971,9 @@ physical_address::from_xml_element(const rapidxml::xml_node<char>& node)
     // </Entry>
 
     auto key_attr = node.first_attribute();
-    EWS_ASSERT(key_attr, "Expected <Entry> to have an attribute");
-    EWS_ASSERT(compare(key_attr->name(), key_attr->name_size(), "Key", 3),
-               "Expected <Entry> to have an attribute 'Key'");
+    check(key_attr, "Expected <Entry> to have an attribute");
+    check(compare(key_attr->name(), key_attr->name_size(), "Key", 3),
+          "Expected <Entry> to have an attribute 'Key'");
     const key key = string_to_physical_address_key(key_attr->value());
 
     std::string street;
@@ -14272,11 +14272,11 @@ im_address::from_xml_element(const rapidxml::xml_node<char>& node)
     //  <Entry Key="ImAddress2">xXSwaggerBoiXx</Entry>
     // </t:ImAddresses>
 
-    EWS_ASSERT(compare(node.local_name(), node.local_name_size(), "Entry",
-                       strlen("Entry")),
-               "Expected <Entry>, got something else");
+    check(compare(node.local_name(), node.local_name_size(), "Entry",
+                  strlen("Entry")),
+          "Expected <Entry>, got something else");
     auto key = node.first_attribute("Key");
-    EWS_ASSERT(key, "Expected attribute 'Key'");
+    check(key, "Expected attribute 'Key'");
     return im_address(
         str_to_im_address_key(std::string(key->value(), key->value_size())),
         std::string(node.value(), node.value_size()));
@@ -14494,11 +14494,11 @@ phone_number::from_xml_element(const rapidxml::xml_node<char>& node)
     //  <Entry Key="BusinessFax">9876543210</Entry>
     // </t:PhoneNumbers>
 
-    EWS_ASSERT(compare(node.local_name(), node.local_name_size(), "Entry",
-                       strlen("Entry")),
-               "Expected <Entry>, got something else");
+    check(compare(node.local_name(), node.local_name_size(), "Entry",
+                  strlen("Entry")),
+          "Expected <Entry>, got something else");
     auto key = node.first_attribute("Key");
-    EWS_ASSERT(key, "Expected attribute 'Key'");
+    check(key, "Expected attribute 'Key'");
     return phone_number(
         str_to_phone_number_key(std::string(key->value(), key->value_size())),
         std::string(node.value(), node.value_size()));
@@ -14685,8 +14685,8 @@ public:
             for (; entry != nullptr; entry = entry->next_sibling())
             {
                 auto key_attr = entry->first_attribute();
-                EWS_ASSERT(key_attr, "Expected an attribute");
-                EWS_ASSERT(
+                check(key_attr, "Expected an attribute");
+                check(
                     compare(key_attr->name(), key_attr->name_size(), "Key", 3),
                     "Expected an attribute 'Key'");
                 const auto key = internal::enum_to_str(address.get_key());
@@ -14764,8 +14764,8 @@ public:
             for (; entry != nullptr; entry = entry->next_sibling())
             {
                 auto key_attr = entry->first_attribute();
-                EWS_ASSERT(key_attr, "Expected an attribute");
-                EWS_ASSERT(
+                check(key_attr, "Expected an attribute");
+                check(
                     compare(key_attr->name(), key_attr->name_size(), "Key", 3),
                     "Expected an attribute 'Key'");
                 const auto key = internal::enum_to_str(address.get_key());
@@ -14833,8 +14833,8 @@ public:
             for (; entry != nullptr; entry = entry->next_sibling())
             {
                 auto key_attr = entry->first_attribute();
-                EWS_ASSERT(key_attr, "Expected an attribute");
-                EWS_ASSERT(
+                check(key_attr, "Expected an attribute");
+                check(
                     compare(key_attr->name(), key_attr->name_size(), "Key", 3),
                     "Expected an attribute 'Key'");
                 const auto key = internal::enum_to_str(number.get_key());
@@ -14994,8 +14994,8 @@ public:
             for (; entry != nullptr; entry = entry->next_sibling())
             {
                 auto key_attr = entry->first_attribute();
-                EWS_ASSERT(key_attr, "Expected an attribute");
-                EWS_ASSERT(
+                check(key_attr, "Expected an attribute");
+                check(
                     compare(key_attr->name(), key_attr->name_size(), "Key", 3),
                     "Expected an attribute 'Key'");
                 const auto key = internal::enum_to_str(im_address.get_key());
@@ -15164,7 +15164,7 @@ public:
     {
         auto id_node =
             elem.first_node_ns(internal::uri<>::microsoft::types(), "ItemId");
-        EWS_ASSERT(id_node, "Expected <ItemId>");
+        check(id_node, "Expected <ItemId>");
         return contact(item_id::from_xml_element(*id_node),
                        internal::xml_subtree(elem));
     }
@@ -15483,8 +15483,7 @@ private:
     rapidxml::xml_node<>&
     to_xml_element_impl(rapidxml::xml_node<>& parent) const override
     {
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be part of a document");
+        check(parent.document(), "Parent node needs to be part of a document");
 
         using namespace internal;
         auto& pattern_node = create_node(parent, "t:RelativeYearlyRecurrence");
@@ -15539,8 +15538,7 @@ private:
     to_xml_element_impl(rapidxml::xml_node<>& parent) const override
     {
         using namespace internal;
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be part of a document");
+        check(parent.document(), "Parent node needs to be part of a document");
 
         auto& pattern_node = create_node(parent, "t:AbsoluteYearlyRecurrence");
         create_node(pattern_node, "t:DayOfMonth",
@@ -15607,8 +15605,7 @@ private:
     to_xml_element_impl(rapidxml::xml_node<>& parent) const override
     {
         using internal::create_node;
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be part of a document");
+        check(parent.document(), "Parent node needs to be part of a document");
 
         auto& pattern_node = create_node(parent, "t:AbsoluteMonthlyRecurrence");
         create_node(pattern_node, "t:Interval", std::to_string(interval_));
@@ -15777,8 +15774,7 @@ private:
     to_xml_element_impl(rapidxml::xml_node<>& parent) const override
     {
         using namespace internal;
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be part of a document");
+        check(parent.document(), "Parent node needs to be part of a document");
 
         auto& pattern_node = create_node(parent, "t:WeeklyRecurrence");
         create_node(pattern_node, "t:Interval", std::to_string(interval_));
@@ -15829,8 +15825,7 @@ private:
     to_xml_element_impl(rapidxml::xml_node<>& parent) const override
     {
         using internal::create_node;
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be part of a document");
+        check(parent.document(), "Parent node needs to be part of a document");
 
         auto& pattern_node = create_node(parent, "t:DailyRecurrence");
         create_node(pattern_node, "t:Interval", std::to_string(interval_));
@@ -15930,8 +15925,7 @@ private:
     to_xml_element_impl(rapidxml::xml_node<>& parent) const override
     {
         using namespace internal;
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be part of a document");
+        check(parent.document(), "Parent node needs to be part of a document");
 
         auto& pattern_node = create_node(parent, "t:NoEndRecurrence");
         create_node(pattern_node, "t:StartDate", start_date_.to_string());
@@ -15981,8 +15975,7 @@ private:
     to_xml_element_impl(rapidxml::xml_node<>& parent) const override
     {
         using internal::create_node;
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be part of a document");
+        check(parent.document(), "Parent node needs to be part of a document");
 
         auto& pattern_node = create_node(parent, "t:EndDateRecurrence");
         create_node(pattern_node, "t:StartDate", start_date_.to_string());
@@ -16040,8 +16033,7 @@ private:
     to_xml_element_impl(rapidxml::xml_node<>& parent) const override
     {
         using namespace internal;
-        EWS_ASSERT(parent.document(),
-                   "Parent node needs to be part of a document");
+        check(parent.document(), "Parent node needs to be part of a document");
 
         auto& pattern_node = create_node(parent, "t:NumberedRecurrence");
         create_node(pattern_node, "t:StartDate", start_date_.to_string());
@@ -16609,7 +16601,7 @@ public:
     {
         auto id_node =
             elem.first_node_ns(internal::uri<>::microsoft::types(), "ItemId");
-        EWS_ASSERT(id_node, "Expected <ItemId>");
+        check(id_node, "Expected <ItemId>");
         return calendar_item(item_id::from_xml_element(*id_node),
                              internal::xml_subtree(elem));
     }
@@ -16855,7 +16847,7 @@ public:
     {
         auto id_node =
             elem.first_node_ns(internal::uri<>::microsoft::types(), "ItemId");
-        EWS_ASSERT(id_node, "Expected <ItemId>");
+        check(id_node, "Expected <ItemId>");
         return message(item_id::from_xml_element(*id_node),
                        internal::xml_subtree(elem));
     }
@@ -16944,7 +16936,7 @@ protected:
     {
         // TODO: we know at compile-time to which class a property belongs
         const auto n = uri_.find(':');
-        EWS_ASSERT((n != std::string::npos), "Expected a ':' in URI");
+        check((n != std::string::npos), "Expected a ':' in URI");
         const auto substr = uri_.substr(0, n);
         if (substr == "folder")
         {
@@ -17023,7 +17015,7 @@ private:
     std::string property_name() const
     {
         const auto n = uri_.rfind(':');
-        EWS_ASSERT((n != std::string::npos), "Expected a ':' in URI");
+        check((n != std::string::npos), "Expected a ':' in URI");
         return uri_.substr(n + 1);
     }
 
@@ -18904,8 +18896,7 @@ public:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.items().empty(),
-                   "Expected at least one item");
+        check(!response_message.items().empty(), "Expected at least one item");
         return response_message.items().front();
     }
 
@@ -18914,7 +18905,7 @@ public:
     get_calendar_items(const std::vector<occurrence_item_id>& ids,
                        const item_shape& shape = item_shape())
     {
-        EWS_ASSERT(!ids.empty(), "Expected at least one item in given vector");
+        check(!ids.empty(), "Expected at least one item in given vector");
 
         std::stringstream sstr;
         sstr << "<m:GetItem>";
@@ -19708,8 +19699,8 @@ public:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.attachment_ids().empty(),
-                   "Expected at least one attachment");
+        check(!response_message.attachment_ids().empty(),
+              "Expected at least one attachment");
         return response_message.attachment_ids().front();
     }
 
@@ -19754,8 +19745,8 @@ public:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.attachments().empty(),
-                   "Expected at least one attachment to be returned");
+        check(!response_message.attachments().empty(),
+              "Expected at least one attachment to be returned");
         return response_message.attachments().front();
     }
 
@@ -19912,19 +19903,19 @@ private:
                 // Get some more helpful details
                 elem = get_element_by_qname(
                     *doc, "LineNumber", internal::uri<>::microsoft::types());
-                EWS_ASSERT(elem, "Expected <LineNumber> element in response");
+                check(elem, "Expected <LineNumber> element in response");
                 const auto line_number =
                     std::stoul(std::string(elem->value(), elem->value_size()));
 
                 elem = get_element_by_qname(
                     *doc, "LinePosition", internal::uri<>::microsoft::types());
-                EWS_ASSERT(elem, "Expected <LinePosition> element in response");
+                check(elem, "Expected <LinePosition> element in response");
                 const auto line_position =
                     std::stoul(std::string(elem->value(), elem->value_size()));
 
                 elem = get_element_by_qname(
                     *doc, "Violation", internal::uri<>::microsoft::types());
-                EWS_ASSERT(elem, "Expected <Violation> element in response");
+                check(elem, "Expected <Violation> element in response");
                 throw schema_validation_error(
                     line_number, line_position,
                     std::string(elem->value(), elem->value_size()));
@@ -19932,7 +19923,7 @@ private:
             else
             {
                 elem = get_element_by_qname(*doc, "faultstring", "");
-                EWS_ASSERT(elem, "Expected <faultstring> element in response");
+                check(elem, "Expected <faultstring> element in response");
                 throw soap_fault(elem->value());
             }
         }
@@ -19973,8 +19964,8 @@ private:
         auto response = request(sstr.str());
         const auto response_message =
             sync_folder_items_result::parse(std::move(response));
-        EWS_ASSERT(!response_message.get_sync_state().empty(),
-                   "Expected at least a sync state");
+        check(!response_message.get_sync_state().empty(),
+              "Expected at least a sync state");
         return response_message;
     }
 
@@ -19998,8 +19989,7 @@ private:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.items().empty(),
-                   "Expected at least one item");
+        check(!response_message.items().empty(), "Expected at least one item");
         return response_message.items().front();
     }
 
@@ -20007,8 +19997,8 @@ private:
     get_folder_impl(const folder_id& id, base_shape shape,
                     const std::vector<property_path>& additional_properties)
     {
-        EWS_ASSERT(!additional_properties.empty(),
-                   "Expected at least one element in additional_properties");
+        check(!additional_properties.empty(),
+              "Expected at least one element in additional_properties");
 
         std::stringstream sstr;
         sstr << "<m:GetFolder>"
@@ -20041,8 +20031,7 @@ private:
     std::vector<folder> get_folders_impl(const std::vector<folder_id>& ids,
                                          base_shape shape)
     {
-        EWS_ASSERT(!ids.empty(),
-                   "Expected at least one element in given vector");
+        check(!ids.empty(), "Expected at least one element in given vector");
 
         std::stringstream sstr;
         sstr << "<m:GetFolder>"
@@ -20073,10 +20062,9 @@ private:
     get_folders_impl(const std::vector<folder_id>& ids, base_shape shape,
                      const std::vector<property_path>& additional_properties)
     {
-        EWS_ASSERT(!ids.empty(),
-                   "Expected at least one element in given vector");
-        EWS_ASSERT(!additional_properties.empty(),
-                   "Expected at least one element in additional_properties");
+        check(!ids.empty(), "Expected at least one element in given vector");
+        check(!additional_properties.empty(),
+              "Expected at least one element in additional_properties");
 
         std::stringstream sstr;
         sstr << "<m:GetFolder>"
@@ -20126,8 +20114,7 @@ private:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.items().empty(),
-                   "Expected at least one item");
+        check(!response_message.items().empty(), "Expected at least one item");
         return response_message.items().front();
     }
 
@@ -20136,7 +20123,7 @@ private:
     std::vector<ItemType> get_item_impl(const std::vector<item_id>& ids,
                                         const item_shape& shape)
     {
-        EWS_ASSERT(!ids.empty(), "Expected at least one id in given vector");
+        check(!ids.empty(), "Expected at least one id in given vector");
 
         std::stringstream sstr;
         sstr << "<m:GetItem>";
@@ -20187,8 +20174,7 @@ private:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.items().empty(),
-                   "Expected at least one item");
+        check(!response_message.items().empty(), "Expected at least one item");
         return response_message.items().front();
     }
 
@@ -20224,8 +20210,7 @@ private:
         {
             throw exchange_error(response_messages.first_error_or_warning());
         }
-        EWS_ASSERT(!response_messages.items().empty(),
-                   "Expected at least one item");
+        check(!response_messages.items().empty(), "Expected at least one item");
 
         const std::vector<ItemType> res_items = response_messages.items();
         std::vector<item_id> res;
@@ -20268,8 +20253,7 @@ private:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.items().empty(),
-                   "Expected a message item");
+        check(!response_message.items().empty(), "Expected a message item");
         return response_message.items().front();
     }
 
@@ -20306,8 +20290,7 @@ private:
         {
             throw exchange_error(response_messages.first_error_or_warning());
         }
-        EWS_ASSERT(!response_messages.items().empty(),
-                   "Expected at least one item");
+        check(!response_messages.items().empty(), "Expected at least one item");
 
         const std::vector<calendar_item> res_items = response_messages.items();
         std::vector<item_id> res;
@@ -20322,7 +20305,7 @@ private:
     folder_id create_folder_impl(const folder& new_folder,
                                  const folder_id& parent_folder)
     {
-        EWS_ASSERT(parent_folder.valid(), "Given parent_folder is not valid");
+        check(parent_folder.valid(), "Given parent_folder is not valid");
 
         std::stringstream sstr;
         sstr << "<m:CreateFolder >"
@@ -20344,8 +20327,7 @@ private:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.items().empty(),
-                   "Expected at least one item");
+        check(!response_message.items().empty(), "Expected at least one item");
         return response_message.items().front();
     }
 
@@ -20353,7 +20335,7 @@ private:
     create_folder_impl(const std::vector<folder>& new_folders,
                        const folder_id& parent_folder)
     {
-        EWS_ASSERT(parent_folder.valid(), "Given parent_folder is not valid");
+        check(parent_folder.valid(), "Given parent_folder is not valid");
 
         std::stringstream sstr;
         sstr << "<m:CreateFolder >"
@@ -20375,8 +20357,7 @@ private:
         {
             throw exchange_error(response_messages.first_error_or_warning());
         }
-        EWS_ASSERT(!response_messages.items().empty(),
-                   "Expected at least one item");
+        check(!response_messages.items().empty(), "Expected at least one item");
 
         const std::vector<folder> items = response_messages.items();
         std::vector<folder_id> res;
@@ -20419,8 +20400,7 @@ private:
 
         if (disposition == message_disposition::save_only)
         {
-            EWS_ASSERT(!response_message.items().empty(),
-                       "Expected a message item");
+            check(!response_message.items().empty(), "Expected a message item");
             return response_message.items().front();
         }
 
@@ -20459,8 +20439,7 @@ private:
         {
             throw exchange_error(response_messages.first_error_or_warning());
         }
-        EWS_ASSERT(!response_messages.items().empty(),
-                   "Expected at least one item");
+        check(!response_messages.items().empty(), "Expected at least one item");
 
         const std::vector<message> items = response_messages.items();
         std::vector<item_id> res;
@@ -20505,8 +20484,7 @@ private:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.items().empty(),
-                   "Expected at least one item");
+        check(!response_message.items().empty(), "Expected at least one item");
         return response_message.items().front();
     }
 
@@ -20549,8 +20527,7 @@ private:
         {
             throw exchange_error(response_message.result());
         }
-        EWS_ASSERT(!response_message.items().empty(),
-                   "Expected at least one item");
+        check(!response_message.items().empty(), "Expected at least one item");
         return response_message.items().front();
     }
 
@@ -20684,7 +20661,7 @@ static_assert(std::is_move_assignable<service>::value, "");
 
 inline void basic_credentials::certify(internal::http_request* request) const
 {
-    EWS_ASSERT(request, "Expected request, got nullptr");
+    check(request, "Expected request, got nullptr");
 
     std::string login = username_ + ":" + password_;
     request->set_option(CURLOPT_USERPWD, login.c_str());
@@ -20693,7 +20670,7 @@ inline void basic_credentials::certify(internal::http_request* request) const
 
 inline void ntlm_credentials::certify(internal::http_request* request) const
 {
-    EWS_ASSERT(request, "Expected request, got nullptr");
+    check(request, "Expected request, got nullptr");
 
     // CURLOPT_USERPWD: domain\username:password
     std::string login =
@@ -20713,7 +20690,7 @@ sync_folder_items_result::parse(internal::http_response&& response)
         internal::get_element_by_qname(*doc, "SyncFolderItemsResponseMessage",
                                        internal::uri<>::microsoft::messages());
 
-    EWS_ASSERT(elem, "Expected <SyncFolderItemsResponseMessage>");
+    check(elem, "Expected <SyncFolderItemsResponseMessage>");
     auto result = internal::parse_response_class_and_code(*elem);
     if (result.cls == response_class::error)
     {
@@ -20722,21 +20699,21 @@ sync_folder_items_result::parse(internal::http_response&& response)
 
     auto sync_state_elem = elem->first_node_ns(
         internal::uri<>::microsoft::messages(), "SyncState");
-    EWS_ASSERT(sync_state_elem, "Expected <SyncState> element");
+    check(sync_state_elem, "Expected <SyncState> element");
     auto sync_state =
         std::string(sync_state_elem->value(), sync_state_elem->value_size());
 
     auto includes_last_item_in_range_elem = elem->first_node_ns(
         internal::uri<>::microsoft::messages(), "IncludesLastItemInRange");
-    EWS_ASSERT(includes_last_item_in_range_elem,
-               "Expected <IncludesLastItemInRange> element");
+    check(includes_last_item_in_range_elem,
+          "Expected <IncludesLastItemInRange> element");
     auto includes_last_item_in_range = rapidxml::internal::compare(
         includes_last_item_in_range_elem->value(),
         includes_last_item_in_range_elem->value_size(), "true", strlen("true"));
 
     auto changes_elem =
         elem->first_node_ns(internal::uri<>::microsoft::messages(), "Changes");
-    EWS_ASSERT(changes_elem, "Expected <Changes> element");
+    check(changes_elem, "Expected <Changes> element");
     std::vector<item_id> created_items;
     std::vector<item_id> updated_items;
     std::vector<item_id> deleted_items;
@@ -20750,7 +20727,7 @@ sync_folder_items_result::parse(internal::http_response&& response)
             {
                 const auto item_id_elem = item_elem.first_node()->first_node_ns(
                     internal::uri<>::microsoft::types(), "ItemId");
-                EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
+                check(item_id_elem, "Expected <ItemId> element");
                 const auto item_id = item_id::from_xml_element(*item_id_elem);
                 created_items.emplace_back(item_id);
             }
@@ -20760,7 +20737,7 @@ sync_folder_items_result::parse(internal::http_response&& response)
             {
                 const auto item_id_elem = item_elem.first_node()->first_node_ns(
                     internal::uri<>::microsoft::types(), "ItemId");
-                EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
+                check(item_id_elem, "Expected <ItemId> element");
                 const auto item_id = item_id::from_xml_element(*item_id_elem);
                 updated_items.emplace_back(item_id);
             }
@@ -20770,7 +20747,7 @@ sync_folder_items_result::parse(internal::http_response&& response)
             {
                 const auto item_id_elem = item_elem.first_node_ns(
                     internal::uri<>::microsoft::types(), "ItemId");
-                EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
+                check(item_id_elem, "Expected <ItemId> element");
                 const auto item_id = item_id::from_xml_element(*item_id_elem);
                 deleted_items.emplace_back(item_id);
             }
@@ -20780,11 +20757,11 @@ sync_folder_items_result::parse(internal::http_response&& response)
             {
                 const auto item_id_elem = item_elem.first_node_ns(
                     internal::uri<>::microsoft::types(), "ItemId");
-                EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
+                check(item_id_elem, "Expected <ItemId> element");
 
                 const auto read_elem = item_elem.first_node_ns(
                     internal::uri<>::microsoft::types(), "IsRead");
-                EWS_ASSERT(read_elem, "Expected <IsRead> element");
+                check(read_elem, "Expected <IsRead> element");
 
                 const auto item_id = item_id::from_xml_element(*item_id_elem);
 
@@ -20817,17 +20794,17 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "CreateFolderResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <CreateFolderResponseMessage>");
+        check(elem, "Expected <CreateFolderResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
         auto item_ids = std::vector<folder_id>();
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "Folders");
-        EWS_ASSERT(items_elem, "Expected <Folders> element");
+        check(items_elem, "Expected <Folders> element");
 
         for_each_child_node(
             *items_elem, [&item_ids](const rapidxml::xml_node<>& item_elem) {
                 auto item_id_elem = item_elem.first_node();
-                EWS_ASSERT(item_id_elem, "Expected <FolderId> element");
+                check(item_id_elem, "Expected <FolderId> element");
                 item_ids.emplace_back(
                     folder_id::from_xml_element(*item_id_elem));
             });
@@ -20842,17 +20819,17 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "CreateItemResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <CreateItemResponseMessage>");
+        check(elem, "Expected <CreateItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
         auto item_ids = std::vector<item_id>();
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "Items");
-        EWS_ASSERT(items_elem, "Expected <Items> element");
+        check(items_elem, "Expected <Items> element");
 
         for_each_child_node(
             *items_elem, [&item_ids](const rapidxml::xml_node<>& item_elem) {
                 auto item_id_elem = item_elem.first_node();
-                EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
+                check(item_id_elem, "Expected <ItemId> element");
                 item_ids.emplace_back(item_id::from_xml_element(*item_id_elem));
             });
         return create_item_response_message(std::move(result),
@@ -20866,7 +20843,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "FindFolderResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <FindFolderResponseMessage>");
+        check(elem, "Expected <FindFolderResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
 
         auto root_folder =
@@ -20874,16 +20851,16 @@ namespace internal
 
         auto items_elem =
             root_folder->first_node_ns(uri<>::microsoft::types(), "Folders");
-        EWS_ASSERT(items_elem, "Expected <t:Folders> element");
+        check(items_elem, "Expected <t:Folders> element");
 
         auto items = std::vector<folder_id>();
         for (auto item_elem = items_elem->first_node(); item_elem;
              item_elem = item_elem->next_sibling())
         {
             // TODO: Check that item is 'FolderId'
-            EWS_ASSERT(item_elem, "Expected an element");
+            check(item_elem, "Expected an element");
             auto item_id_elem = item_elem->first_node();
-            EWS_ASSERT(item_id_elem, "Expected <FolderId> element");
+            check(item_id_elem, "Expected <FolderId> element");
             items.emplace_back(folder_id::from_xml_element(*item_id_elem));
         }
         return find_folder_response_message(std::move(result),
@@ -20897,7 +20874,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "FindItemResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <FindItemResponseMessage>");
+        check(elem, "Expected <FindItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
 
         auto root_folder =
@@ -20905,15 +20882,15 @@ namespace internal
 
         auto items_elem =
             root_folder->first_node_ns(uri<>::microsoft::types(), "Items");
-        EWS_ASSERT(items_elem, "Expected <t:Items> element");
+        check(items_elem, "Expected <t:Items> element");
 
         auto items = std::vector<item_id>();
         for (auto item_elem = items_elem->first_node(); item_elem;
              item_elem = item_elem->next_sibling())
         {
-            EWS_ASSERT(item_elem, "Expected an element");
+            check(item_elem, "Expected an element");
             auto item_id_elem = item_elem->first_node();
-            EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
+            check(item_id_elem, "Expected <ItemId> element");
             items.emplace_back(item_id::from_xml_element(*item_id_elem));
         }
         return find_item_response_message(std::move(result), std::move(items));
@@ -20926,7 +20903,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "FindItemResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <FindItemResponseMessage>");
+        check(elem, "Expected <FindItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
 
         auto root_folder =
@@ -20934,7 +20911,7 @@ namespace internal
 
         auto items_elem =
             root_folder->first_node_ns(uri<>::microsoft::types(), "Items");
-        EWS_ASSERT(items_elem, "Expected <t:Items> element");
+        check(items_elem, "Expected <t:Items> element");
 
         auto items = std::vector<calendar_item>();
         for_each_child_node(
@@ -20952,20 +20929,20 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "UpdateItemResponseMessage",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <UpdateItemResponseMessage>");
+        check(elem, "Expected <UpdateItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
 
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "Items");
-        EWS_ASSERT(items_elem, "Expected <m:Items> element");
+        check(items_elem, "Expected <m:Items> element");
 
         auto items = std::vector<item_id>();
         for (auto item_elem = items_elem->first_node(); item_elem;
              item_elem = item_elem->next_sibling())
         {
-            EWS_ASSERT(item_elem, "Expected an element");
+            check(item_elem, "Expected an element");
             auto item_id_elem = item_elem->first_node();
-            EWS_ASSERT(item_id_elem, "Expected <ItemId> element");
+            check(item_id_elem, "Expected <ItemId> element");
             items.emplace_back(item_id::from_xml_element(*item_id_elem));
         }
         return update_item_response_message(std::move(result),
@@ -20978,11 +20955,11 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto elem = get_element_by_qname(*doc, "GetFolderResponseMessage",
                                          uri<>::microsoft::messages());
-        EWS_ASSERT(elem, "Expected <GetFolderResponseMessage>");
+        check(elem, "Expected <GetFolderResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "Folders");
-        EWS_ASSERT(items_elem, "Expected <Folders> element");
+        check(items_elem, "Expected <Folders> element");
         auto items = std::vector<folder>();
         for_each_child_node(
             *items_elem, [&items](const rapidxml::xml_node<>& item_elem) {
@@ -20998,12 +20975,12 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "GetRoomListsResponse",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <GetRoomListsResponse>");
+        check(elem, "Expected <GetRoomListsResponse>");
         auto result = parse_response_class_and_code(*elem);
         auto room_lists = std::vector<mailbox>();
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "RoomLists");
-        EWS_ASSERT(items_elem, "Expected <RoomLists> element");
+        check(items_elem, "Expected <RoomLists> element");
 
         for_each_child_node(
             *items_elem, [&room_lists](const rapidxml::xml_node<>& item_elem) {
@@ -21020,7 +20997,7 @@ namespace internal
         auto elem = get_element_by_qname(*doc, "GetRoomsResponse",
                                          uri<>::microsoft::messages());
 
-        EWS_ASSERT(elem, "Expected <GetRoomsResponse>");
+        check(elem, "Expected <GetRoomsResponse>");
         auto result = parse_response_class_and_code(*elem);
         auto rooms = std::vector<mailbox>();
         auto items_elem =
@@ -21035,7 +21012,7 @@ namespace internal
             *items_elem, [&rooms](const rapidxml::xml_node<>& item_elem) {
                 auto room_elem =
                     item_elem.first_node_ns(uri<>::microsoft::types(), "Id");
-                EWS_ASSERT(room_elem, "Expected <Id> element");
+                check(room_elem, "Expected <Id> element");
                 rooms.emplace_back(mailbox::from_xml_element(*room_elem));
             });
         return get_rooms_response_message(std::move(result), std::move(rooms));
@@ -21048,7 +21025,7 @@ namespace internal
 
         auto response_messages = get_element_by_qname(
             *doc, "ResponseMessages", uri<>::microsoft::messages());
-        EWS_ASSERT(response_messages, "Expected <ResponseMessages> node");
+        check(response_messages, "Expected <ResponseMessages> node");
 
         std::vector<folder_response_message::response_message> messages;
         for_each_child_node(
@@ -21057,7 +21034,7 @@ namespace internal
 
                 auto items_elem =
                     node.first_node_ns(uri<>::microsoft::messages(), "Folders");
-                EWS_ASSERT(items_elem, "Expected <Folders> element");
+                check(items_elem, "Expected <Folders> element");
 
                 auto items = std::vector<folder>();
                 for_each_child_node(
@@ -21080,11 +21057,11 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto elem = get_element_by_qname(*doc, "GetItemResponseMessage",
                                          uri<>::microsoft::messages());
-        EWS_ASSERT(elem, "Expected <GetItemResponseMessage>");
+        check(elem, "Expected <GetItemResponseMessage>");
         auto result = parse_response_class_and_code(*elem);
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "Items");
-        EWS_ASSERT(items_elem, "Expected <Items> element");
+        check(items_elem, "Expected <Items> element");
         auto items = std::vector<ItemType>();
         for_each_child_node(
             *items_elem, [&items](const rapidxml::xml_node<>& item_elem) {
@@ -21101,7 +21078,7 @@ namespace internal
 
         auto response_messages = get_element_by_qname(
             *doc, "ResponseMessages", uri<>::microsoft::messages());
-        EWS_ASSERT(response_messages, "Expected <ResponseMessages> node");
+        check(response_messages, "Expected <ResponseMessages> node");
 
         std::vector<item_response_messages::response_message> messages;
         for_each_child_node(
@@ -21110,7 +21087,7 @@ namespace internal
 
                 auto items_elem =
                     node.first_node_ns(uri<>::microsoft::messages(), "Items");
-                EWS_ASSERT(items_elem, "Expected <Items> element");
+                check(items_elem, "Expected <Items> element");
 
                 auto items = std::vector<ItemType>();
                 for_each_child_node(
@@ -21165,7 +21142,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(*doc, "AddDelegateResponse",
                                                   uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem, "Expected <AddDelegateResponse>");
+        check(response_elem, "Expected <AddDelegateResponse>");
         auto result = parse_response_class_and_code(*response_elem);
 
         std::vector<delegate_user> delegates;
@@ -21183,7 +21160,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(*doc, "GetDelegateResponse",
                                                   uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem, "Expected <GetDelegateResponse>");
+        check(response_elem, "Expected <GetDelegateResponse>");
         auto result = parse_response_class_and_code(*response_elem);
 
         std::vector<delegate_user> delegates;
@@ -21201,7 +21178,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto resp = get_element_by_qname(*doc, "RemoveDelegateResponse",
                                          uri<>::microsoft::messages());
-        EWS_ASSERT(resp, "Expected <RemoveDelegateResponse>");
+        check(resp, "Expected <RemoveDelegateResponse>");
 
         auto result = parse_response_class_and_code(*resp);
         if (result.code == response_code::no_error)
@@ -21233,8 +21210,8 @@ namespace internal
                                 auto rcode_elem = msg.first_node_ns(
                                     uri<>::microsoft::messages(),
                                     "ResponseCode");
-                                EWS_ASSERT(rcode_elem,
-                                           "Expected <ResponseCode> element");
+                                check(rcode_elem,
+                                      "Expected <ResponseCode> element");
                                 code =
                                     str_to_response_code(rcode_elem->value());
 
@@ -21267,7 +21244,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(
             *doc, "ResolveNamesResponseMessage", uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem, "Expected <ResolveNamesResponseMessage>");
+        check(response_elem, "Expected <ResolveNamesResponseMessage>");
         auto result = parse_response_class_and_code(*response_elem);
 
         resolution_set resolutions;
@@ -21277,8 +21254,7 @@ namespace internal
         {
             auto resolution_set_element = response_elem->first_node_ns(
                 uri<>::microsoft::messages(), "ResolutionSet");
-            EWS_ASSERT(resolution_set_element,
-                       "Expected <ResolutionSet> element");
+            check(resolution_set_element, "Expected <ResolutionSet> element");
 
             for (auto attr = resolution_set_element->first_attribute();
                  attr != nullptr; attr = attr->next_attribute())
@@ -21340,7 +21316,7 @@ namespace internal
                      uri<>::microsoft::types(), "Resolution");
                  res; res = res->next_sibling())
             {
-                EWS_ASSERT(res, "Expected <Resolution> element");
+                check(res, "Expected <Resolution> element");
                 resolution r;
 
                 if (compare("Mailbox", strlen("Mailbox"),
@@ -21375,7 +21351,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(
             *doc, "SubscribeResponseMessage", uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem, "Expected <SubscribeResponseMessage>");
+        check(response_elem, "Expected <SubscribeResponseMessage>");
         auto result = parse_response_class_and_code(*response_elem);
 
         std::string id;
@@ -21404,7 +21380,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(
             *doc, "UnsubscribeResponseMessage", uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem, "Expected <UnsubscribeResponseMessage>");
+        check(response_elem, "Expected <UnsubscribeResponseMessage>");
         auto result = parse_response_class_and_code(*response_elem);
 
         return unsubscribe_response_message(std::move(result));
@@ -21417,7 +21393,7 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto response_elem = get_element_by_qname(
             *doc, "GetEventsResponseMessage", uri<>::microsoft::messages());
-        EWS_ASSERT(response_elem, "Expected <GetEventsResponseMessage>");
+        check(response_elem, "Expected <GetEventsResponseMessage>");
         auto result = parse_response_class_and_code(*response_elem);
 
         notification n;
@@ -21425,7 +21401,7 @@ namespace internal
         {
             auto notification_element = response_elem->first_node_ns(
                 uri<>::microsoft::messages(), "Notification");
-            EWS_ASSERT(notification_element, "Expected <Notification> element");
+            check(notification_element, "Expected <Notification> element");
 
             n.subscription_id =
                 notification_element
@@ -21597,7 +21573,7 @@ inline attachment attachment::from_item(const item& the_item,
         if (node)
         {
             auto parent = node->parent();
-            EWS_ASSERT(parent, "Expected node to have a parent node");
+            check(parent, "Expected node to have a parent node");
             parent->remove_node(node);
         }
     }
@@ -21711,9 +21687,9 @@ recurrence_pattern::from_xml_element(const rapidxml::xml_node<>& elem)
     using rapidxml::internal::compare;
     using namespace internal;
 
-    EWS_ASSERT(compare(elem.local_name(), elem.local_name_size(), "Recurrence",
-                       strlen("Recurrence")),
-               "Expected a <Recurrence> element");
+    check(compare(elem.local_name(), elem.local_name_size(), "Recurrence",
+                  strlen("Recurrence")),
+          "Expected a <Recurrence> element");
 
     auto node = elem.first_node_ns(uri<>::microsoft::types(),
                                    "AbsoluteYearlyRecurrence");
@@ -21937,11 +21913,10 @@ recurrence_pattern::from_xml_element(const rapidxml::xml_node<>& elem)
 #endif
     }
 
-    EWS_ASSERT(false,
-               "Expected one of "
-               "<AbsoluteYearlyRecurrence>, <RelativeYearlyRecurrence>, "
-               "<AbsoluteMonthlyRecurrence>, <RelativeMonthlyRecurrence>, "
-               "<WeeklyRecurrence>, <DailyRecurrence>");
+    check(false, "Expected one of "
+                 "<AbsoluteYearlyRecurrence>, <RelativeYearlyRecurrence>, "
+                 "<AbsoluteMonthlyRecurrence>, <RelativeMonthlyRecurrence>, "
+                 "<WeeklyRecurrence>, <DailyRecurrence>");
     return std::unique_ptr<recurrence_pattern>();
 }
 
@@ -21950,9 +21925,9 @@ recurrence_range::from_xml_element(const rapidxml::xml_node<>& elem)
 {
     using rapidxml::internal::compare;
 
-    EWS_ASSERT(compare(elem.local_name(), elem.local_name_size(), "Recurrence",
-                       strlen("Recurrence")),
-               "Expected a <Recurrence> element");
+    check(compare(elem.local_name(), elem.local_name_size(), "Recurrence",
+                  strlen("Recurrence")),
+          "Expected a <Recurrence> element");
 
     auto node = elem.first_node_ns(internal::uri<>::microsoft::types(),
                                    "NoEndRecurrence");
@@ -22048,11 +22023,9 @@ recurrence_range::from_xml_element(const rapidxml::xml_node<>& elem)
 #endif
     }
 
-    EWS_ASSERT(false,
-               "Expected one of "
-               "<NoEndRecurrence>, <EndDateRecurrence>, <NumberedRecurrence>");
+    check(false,
+          "Expected one of "
+          "<NoEndRecurrence>, <EndDateRecurrence>, <NumberedRecurrence>");
     return std::unique_ptr<recurrence_range>();
 }
 } // namespace ews
-
-#undef EWS_ASSERT

--- a/include/ews/ews_fwd.hpp
+++ b/include/ews/ews_fwd.hpp
@@ -29,6 +29,7 @@
 namespace ews
 {
 class and_;
+class assertion_error;
 class attachment;
 class attachment_id;
 class attendee;

--- a/tests/assets/bogus_server.py
+++ b/tests/assets/bogus_server.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+"""Launch small HTTP server for TimeoutTest test case
+
+Should work with Python 2 and 3.
+
+"""
+
+import sys
+import time
+
+try:
+    from SimpleHTTPServer import SimpleHTTPRequestHandler as RequestHandler
+except ImportError:
+    from http.server import CGIHTTPRequestHandler as RequestHandler
+
+try:
+    from SocketServer import TCPServer as HTTPServer
+except ImportError:
+    from http.server import HTTPServer
+
+
+PYTHON_VERSION = sys.version_info[0]
+
+class Handler(RequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/xml")
+        self.end_headers()
+        response_string = """
+<?xml version="1.0" encoding="utf-8" ?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Header>
+    <t:ServerVersionInfo MajorVersion="8" MinorVersion="0" MajorBuildNumber="685" MinorBuildNumber="8"
+                         xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" />
+  </soap:Header>
+  <soap:Body>
+    <BogusResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                   xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                   xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+      <m:ResponseMessages>
+        <m:BogusResponseMessage ResponseClass="Success">
+          <m:ResponseCode>NoError</m:ResponseCode>
+        </m:BogusResponseMessage>
+      </m:ResponseMessages>
+    </BogusResponse>
+  </soap:Body>
+</soap:Envelope>
+        """
+        if PYTHON_VERSION is 3:
+            response = bytes(response_string, "utf-8")
+        else:
+            response = response_string
+        self.wfile.write(response)
+
+    def do_POST(self):
+        self.do_GET()
+
+    def log_message(self, format, *args):
+        return
+
+
+server = HTTPServer(("localhost", 8080), Handler)
+server.serve_forever()

--- a/tests/test_timeout.cpp
+++ b/tests/test_timeout.cpp
@@ -17,7 +17,7 @@ namespace tests
 {
 namespace timeout_test
 {
-    inline void start(std::string dir)
+    inline void start(const std::string& dir)
     {
         static bool server_started = false;
         if (!server_started)


### PR DESCRIPTION
Address issue #111 by always enabling run-time checks.

Overview of the changes in this PR:
- EWS_ASSERT is now a normal function (`ews::check`) that throws an exception instead of triggering a SIGABRT via assert(3)
- every run-time check that was EWS_ASSERT before is now always enabled, this of course includes release builds
- there is now a little Python HTTP server that returns a fake response

If we want to guard against more bogus responses or even against malicious servers we need to do more testing, though. (Maybe fuzzing could help here?)