### PR TITLE
Fix SyncFolderItems requested shape

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -21243,8 +21243,10 @@ private:
         std::stringstream sstr;
         sstr << "<m:SyncFolderItems>"
                 "<m:ItemShape>"
-             << internal::enum_to_str(ews::base_shape::id_only)
-             << "</m:ItemShape>"
+                "<t:BaseShape>"
+             << internal::enum_to_str(base_shape::id_only)
+             << "</t:BaseShape>"
+                "</m:ItemShape>"
                 "<m:SyncFolderId>"
              << folder_id.to_xml() << "</m:SyncFolderId>";
         if (!sync_state.empty())


### PR DESCRIPTION
The ItemShape note was missing the BaseShape note. Instead it
had the actual id_only shape as the value of ItemShape.
I guess it only worked because the Exchange server ignored
the value and defaulted to id_only.

It was
`<ItemShape>
        Default
      </ItemShape>`
instead of
`<ItemShape>
        <t:BaseShape>Default</t:BaseShape>
      </ItemShape>`