### PR TITLE
Folder fixes

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -12976,6 +12976,14 @@ public:
         return std::stoi(xml().get_value_as_string("ChildFolderCount"));
     }
 
+    //! Returns the id of the parent folder
+    folder_id get_parent_folder_id() const
+    {
+        auto parent_id_node = xml().get_node("ParentFolderId");
+        check(parent_id_node, "Expected <ParentFolderId>");
+        return folder_id::from_xml_element(*parent_id_node);
+    }
+
     //! Returns the number of unread items in this folder
     int get_unread_count() const
     {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -9649,7 +9649,7 @@ public:
     static folder_id from_xml_element(const rapidxml::xml_node<>& elem)
     {
         auto id_attr = elem.first_attribute("Id");
-        check(id_attr, "Expected <ParentFolderId> to have an Id attribute");
+        check(id_attr, "Expected <Id> to have an Id attribute");
         auto id = std::string(id_attr->value(), id_attr->value_size());
 
         std::string change_key;

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -20193,7 +20193,7 @@ public:
     folder get_folder(const folder_id& id,
                       const std::vector<property_path>& additional_properties)
     {
-        return get_folder_impl(id, base_shape::default_shape,
+        return get_folder_impl(id, base_shape::all_properties,
                                additional_properties);
     }
 

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -21432,13 +21432,14 @@ private:
                 "</m:GetFolder>";
 
         auto response = request(sstr.str());
-        const auto response_messages =
+        const auto response_message =
             internal::folder_response_message::parse(std::move(response));
-        if (!response_messages.success())
+        if (!response_message.success())
         {
-            throw exchange_error(response_messages.first_error_or_warning());
+            throw exchange_error(response_message.first_error_or_warning());
         }
-        return response_messages.items();
+        check(!response_message.items().empty(), "Expected at least one item");
+        return response_message.items().front();
     }
 
     std::vector<folder> get_folders_impl(const std::vector<folder_id>& ids,


### PR DESCRIPTION
Some fixes regarding folders and their respective functions.

Most important is a fix on get_folder_impl which caused an compilation error when used.
I still don't understand why it did compile in the first place.