### PR TITLE
Fix parsing of SyncFolderItems response

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -22625,9 +22625,9 @@ sync_folder_items_result::parse(internal::http_response&& response)
 
                 const auto item_id = item_id::from_xml_element(*item_id_elem);
 
-                const bool read = compare(read_elem->local_name(),
-                                          read_elem->local_name_size(), "true",
-                                          strlen("true"));
+                const bool read =
+                    compare(read_elem->value(), read_elem->value_size(), "true",
+                            strlen("true"));
 
                 read_flag_changed.emplace_back(std::make_pair(item_id, read));
             }


### PR DESCRIPTION
Regarding Issue #131 

The response contains information of items whose read flag changed.
Including a bool with true for read and false for unread. This hasn't
been parsed correctly and always returned false for each element.