### PR TITLE
Fix parsing of GetRoomLists response on error

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -22861,9 +22861,14 @@ namespace internal
         const auto doc = parse_response(std::move(response));
         auto elem = get_element_by_qname(*doc, "GetRoomListsResponse",
                                          uri<>::microsoft::messages());
-
         check(elem, "Expected <GetRoomListsResponse>");
+
         auto result = parse_response_class_and_code(*elem);
+        if (result.cls == response_class::error)
+        {
+            throw exchange_error(result);
+        }
+
         auto room_lists = std::vector<mailbox>();
         auto items_elem =
             elem->first_node_ns(uri<>::microsoft::messages(), "RoomLists");


### PR DESCRIPTION
Regarding issue #138 get_room_lists from outlook.com

When the response of GetRoomLists has the ResponseClass Error, we
immediately throw an exchange_error. Instead of expecting the
RoomLists element to be there and throwing an assertion_error. The
Exchange server behind outlook.com (formerly hotmail.com) doesn't
allow access to room management.

