### PR TITLE
Contact property paths

### DIFF
--- a/examples/update_contact.cpp
+++ b/examples/update_contact.cpp
@@ -44,9 +44,28 @@ int main()
         for (const auto& id : item_ids)
         {
             auto contact = service.get_contact(id);
+            
+            std::vector<ews::update> update_list;
+            
             auto job_title_property = ews::property(
                 ews::contact_property_path::job_title, "Superhero");
-            auto new_id = service.update_item(id, job_title_property);
+            update_list.emplace_back(job_title_property);
+            
+            ews::physical_address city(ews::physical_address:key::business,
+               "", "Metropolis", "", "", "")
+            auto business_city_property = ews::property(
+                ews::contact_property_path::physical_address::business::city,
+                city);
+            update_list.emplace_back(business_city_property);
+            
+            ews::physical_address street(ews::physical_address:key::business,
+                "SuperStreet", "", "", "", "");
+            auto business_city_property = ews::property(
+                ews::contact_property_path::physical_address::business::street,
+                street);
+            update_list.emplace_back(business_city_property);
+                
+            auto new_id = service.update_item(id, update_list);
             (void)new_id;
 
 // TODO: check this!

--- a/examples/update_contact.cpp
+++ b/examples/update_contact.cpp
@@ -51,14 +51,14 @@ int main()
                 ews::contact_property_path::job_title, "Superhero");
             update_list.emplace_back(job_title_property);
             
-            ews::physical_address city(ews::physical_address:key::business,
-               "", "Metropolis", "", "", "")
+            ews::physical_address city(ews::physical_address::key::business,
+               "", "Metropolis", "", "", "");
             auto business_city_property = ews::property(
                 ews::contact_property_path::physical_address::business::city,
                 city);
             update_list.emplace_back(business_city_property);
             
-            ews::physical_address street(ews::physical_address:key::business,
+            ews::physical_address street(ews::physical_address::key::business,
                 "SuperStreet", "", "", "", "");
             auto business_city_property = ews::property(
                 ews::contact_property_path::physical_address::business::street,

--- a/examples/update_contact.cpp
+++ b/examples/update_contact.cpp
@@ -60,10 +60,10 @@ int main()
             
             ews::physical_address street(ews::physical_address::key::business,
                 "SuperStreet", "", "", "", "");
-            auto business_city_property = ews::property(
+            auto business_street_property = ews::property(
                 ews::contact_property_path::physical_address::business::street,
                 street);
-            update_list.emplace_back(business_city_property);
+            update_list.emplace_back(business_street_property);
                 
             auto new_id = service.update_item(id, update_list);
             (void)new_id;

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18960,6 +18960,10 @@ public:
     //! Use this constructor if you want to delete a property from an item
     explicit property(property_path path) : value_(path.to_xml()) {}
 
+    //! Use this constructor if you want to delete an indexed property from an
+    //! item
+    explicit property(indexed_property_path path) : value_(path.to_xml()) {}
+
     // Use this constructor (and following overloads) whenever you want to
     // set or update an item's property
     property(property_path path, const std::string& value)

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18770,12 +18770,44 @@ namespace contact_property_path
 
     namespace phone_number
     {
-        static const indexed_property_path home_phone("contacts:PhoneNumber",
-                                                      "HomePhone");
-        static const indexed_property_path pager("contacts:PhoneNumber",
-                                                 "Pager");
+        static const indexed_property_path
+            assistant_phone("contacts:PhoneNumber", "AssistantPhone");
+        static const indexed_property_path business_fax("contacts:PhoneNumber",
+                                                        "BusinessFax");
         static const indexed_property_path
             business_phone("contacts:PhoneNumber", "BusinessPhone");
+        static const indexed_property_path
+            business_phone_2("contacts:PhoneNumber", "BusinessPhone2");
+        static const indexed_property_path callback("contacts:PhoneNumber",
+                                                    "Callback");
+        static const indexed_property_path car_phone("contacts:PhoneNumber",
+                                                     "CarPhone");
+        static const indexed_property_path
+            company_main_phone("contacts:PhoneNumber", "CompanyMainPhone");
+        static const indexed_property_path home_fax("contacts:PhoneNumber",
+                                                    "HomeFax");
+        static const indexed_property_path home_phone("contacts:PhoneNumber",
+                                                      "HomePhone");
+        static const indexed_property_path home_phone_2("contacts:PhoneNumber",
+                                                        "HomePhone2");
+        static const indexed_property_path isdn("contacts:PhoneNumber", "Isdn");
+
+        static const indexed_property_path mobile_phone("contacts:PhoneNumber",
+                                                        "MobilePhone");
+        static const indexed_property_path other_fax("contacts:PhoneNumber",
+                                                     "OtherFax");
+        static const indexed_property_path
+            other_telephone("contacts:PhoneNumber", "OtherTelephone");
+        static const indexed_property_path pager("contacts:PhoneNumber",
+                                                 "Pager");
+        static const indexed_property_path primary_phone("contacts:PhoneNumber",
+                                                         "PrimaryPhone");
+        static const indexed_property_path radio_phone("contacts:PhoneNumber",
+                                                       "RadioPhone");
+        static const indexed_property_path telex("contacts:PhoneNumber",
+                                                 "Telex");
+        static const indexed_property_path tty_tdd_phone("contacts:PhoneNumber",
+                                                         "TtyTddPhone");
     } // namespace phone_number
 
     static const property_path phonetic_full_name = "contacts:PhoneticFullName";

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -18820,17 +18820,49 @@ namespace contact_property_path
 
     namespace physical_address
     {
-        static const indexed_property_path street("contacts:PhysicalAddress",
-                                                  "Street");
-        static const indexed_property_path city("contacts:PhysicalAddress:City",
-                                                "Home");
-        static const indexed_property_path state("contacts:PhysicalAddress",
-                                                 "State");
-        static const indexed_property_path
-            country_or_region("contacts:PhysicalAddress", "CountryOrRegion");
-        static const indexed_property_path
-            postal_code("contacts:PhysicalAddress", "PostalCode");
-    } // namespace physical_address
+        namespace business
+        {
+            static const indexed_property_path
+                street("contacts:PhysicalAddress:Street", "Business");
+            static const indexed_property_path
+                city("contacts:PhysicalAddress:City", "Business");
+            static const indexed_property_path
+                state("contacts:PhysicalAddress:State", "Business");
+            static const indexed_property_path
+                country_or_region("contacts:PhysicalAddress:CountryOrRegion",
+                                  "Business");
+            static const indexed_property_path
+                postal_code("contacts:PhysicalAddress:PostalCode", "Business");
+        } // namespace business
+        namespace home
+        {
+            static const indexed_property_path
+                street("contacts:PhysicalAddress:Street", "Home");
+            static const indexed_property_path
+                city("contacts:PhysicalAddress:City", "Home");
+            static const indexed_property_path
+                state("contacts:PhysicalAddress:State", "Home");
+            static const indexed_property_path
+                country_or_region("contacts:PhysicalAddress:CountryOrRegion",
+                                  "Home");
+            static const indexed_property_path
+                postal_code("contacts:PhysicalAddress:PostalCode", "Home");
+        } // namespace home
+        namespace other
+        {
+            static const indexed_property_path
+                street("contacts:PhysicalAddress:Street", "Other");
+            static const indexed_property_path
+                city("contacts:PhysicalAddress:City", "Other");
+            static const indexed_property_path
+                state("contacts:PhysicalAddress:State", "Other");
+            static const indexed_property_path
+                country_or_region("contacts:PhysicalAddress:CountryOrRegion",
+                                  "Other");
+            static const indexed_property_path
+                postal_code("contacts:PhysicalAddress:PostalCode", "Other");
+        } // namespace other
+    }     // namespace physical_address
 
     static const property_path postal_address_index =
         "contacts:PostalAddressIndex";

--- a/tests/test_contacts.cpp
+++ b/tests/test_contacts.cpp
@@ -651,7 +651,7 @@ TEST_F(ContactTest, UpdatePhysicalAddressesValues)
     auto address = ews::physical_address(ews::physical_address::key::home, "",
                                          "Duckburg", "", "", "");
     auto prop = ews::property(
-        ews::contact_property_path::physical_address::city, address);
+        ews::contact_property_path::physical_address::business::city, address);
     auto new_id = service().update_item(minnie.get_item_id(), prop);
     minnie = service().get_contact(new_id);
     ASSERT_FALSE(minnie.get_physical_addresses().empty());


### PR DESCRIPTION
Add and fix some of the contact property paths to allow
updating the various phone numbers and physical address entries.

Though it has to be mentioned, updating the physical address is a
little tedious. Each item of a physical address requires it's own update
item. So, when creating a physical_address item for an update, only
one of the address items has to be set. The others have be left empty.
I added examples to the update_contact.cpp example which shows
how the city and the street is updated.

Regarding issue #141 