### PR TITLE
Support updating extended properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,7 @@ if(HAS_VARIANT AND NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
     add_example(subscribe)
 endif()
 add_example(update_contact)
+add_example(update_extended_property)
 add_example(update_folder)
 
 # Python is optional as it is only used by TimeoutTest

--- a/examples/update_extended_property.cpp
+++ b/examples/update_extended_property.cpp
@@ -1,0 +1,66 @@
+
+//   Copyright 2016 otris software AG
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#include <ews/ews.hpp>
+#include <ews/ews_test_support.hpp>
+#include <exception>
+#include <iostream>
+#include <ostream>
+#include <stdlib.h>
+#include <string>
+
+int main()
+{
+    int res = EXIT_SUCCESS;
+    ews::set_up();
+
+    try
+    {
+        const auto env = ews::test::environment();
+        auto service = ews::service(env.server_uri, env.domain, env.username,
+                                    env.password);
+
+        ews::distinguished_folder_id contacts_folder =
+            ews::standard_folder::contacts;
+        auto restriction =
+            ews::is_equal_to(ews::contact_property_path::email_address_1,
+                             "superhero@ducktales.com");
+        auto item_ids = service.find_item(contacts_folder, restriction);
+
+        std::cout << "Found " << item_ids.size() << " item(s)\n";
+
+        for (const auto& id : item_ids)
+        {
+            auto contact = service.get_contact(id);
+
+            ews::extended_field_uri::property_type title_prop_type("String");
+            ews::extended_field_uri::property_tag title_prop_id("14917");
+            ews::extended_field_uri title_prop_uri(title_prop_id, title_prop_type);
+            ews::extended_property title_prop(title_prop_uri, { "el presidente" });
+            ews::update update(title_prop);
+
+            auto new_id = service.update_item(id, update);
+            (void)new_id;
+        }
+    }
+    catch (std::exception& exc)
+    {
+        std::cout << exc.what() << std::endl;
+        res = EXIT_FAILURE;
+    }
+
+    ews::tear_down();
+    return res;
+}

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -20069,9 +20069,15 @@ public:
 
     // intentionally not explicit
     update(property prop, operation action = operation::set_item_field)
-        : prop_(std::move(prop)), op_(std::move(action))
+        : prop_(std::move(prop.to_xml())), op_(std::move(action))
     {
     }
+
+    update(extended_property prop, operation action = operation::set_item_field)
+        : prop_(std::move(prop.to_xml())), op_(std::move(action))
+    {
+    }
+
 
     //! Serializes this update instance to an XML string for item operations
     std::string to_item_xml() const
@@ -20087,7 +20093,7 @@ public:
         }
         std::stringstream sstr;
         sstr << "<t:" << action << ">";
-        sstr << prop_.to_xml();
+        sstr << prop_;
         sstr << "</t:" << action << ">";
         return sstr.str();
     }
@@ -20106,13 +20112,13 @@ public:
         }
         std::stringstream sstr;
         sstr << "<t:" << action << ">";
-        sstr << prop_.to_xml();
+        sstr << prop_;
         sstr << "</t:" << action << ">";
         return sstr.str();
     }
 
 private:
-    property prop_;
+    std::string prop_;
     update::operation op_;
 };
 

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -13018,6 +13018,7 @@ public:
 
     static extended_property
     from_xml_element(const rapidxml::xml_node<char>& node); // defined below
+    std::string to_xml() const;
 
     //! Returns the the extended_field_uri element of this
     //! extended_property.
@@ -13046,6 +13047,26 @@ static_assert(std::is_copy_assignable<extended_property>::value);
 static_assert(std::is_move_constructible<extended_property>::value);
 static_assert(std::is_move_assignable<extended_property>::value);
 #endif
+
+inline std::string extended_property::to_xml() const
+{
+    std::stringstream sstr;
+
+    auto values = get_values();
+    auto efu = get_extended_field_uri();
+    for (auto&& v : values) {
+        sstr << efu.to_xml();
+        sstr << "<t:Message>";
+        sstr << "<t:ExtendedProperty>"
+             << efu.to_xml();
+        sstr << "<t:Value>"
+             << v
+             << "</t:Value>";
+        sstr << "</t:ExtendedProperty>";
+        sstr << "</t:Message>";
+    }
+    return sstr.str();
+}
 
 inline extended_property
 extended_property::from_xml_element(const rapidxml::xml_node<char>& top_node)


### PR DESCRIPTION
Reworked and expanded extended_property with to_xml and from_xml_element.
The first one is relevant for the ability to update extended_properties, because I changed update to store a property as a string instead of a property. This way we can support extended_property easily.

Should close #142 . 