### PR TITLE
Fix event_type to and from string

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -7413,6 +7413,8 @@ namespace internal
             return "DeletedEvent";
         case event_type::modified_event:
             return "ModifiedEvent";
+        case event_type::moved_event:
+            return "MovedEvent";
         case event_type::new_mail_event:
             return "NewMailEvent";
         case event_type::status_event:
@@ -7441,6 +7443,10 @@ namespace internal
         else if (str == "ModifiedEvent")
         {
             return event_type::modified_event;
+        }
+        else if (str == "MovedEvent")
+        {
+            return event_type::moved_event;
         }
         else if (str == "NewMailEvent")
         {


### PR DESCRIPTION
The conversion functions for event_type were missing the
event_type::moved_event case.

I was looking into Pull-Subscriptions when I noticed that those
functions seemed a bit off. I hope this event wasn't missing
intentionally. But I couldn't imagine a reason why it would.