### PR TITLE
Add mime content to item attachments

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -10901,7 +10901,7 @@ public:
         const auto attachment_node = xml_.root();
         if (!attachment_node)
         {
-            return nullptr;
+            return "";
         }
 
         rapidxml::xml_node<>* node = nullptr;


### PR DESCRIPTION
It's now possible to request the mime content when retrieving an item
attachment. The attachment class has a function to extract the mime
content of the attached item.

I needed to get the item attachments as a file.
To do so, I added the option to request the mime content when calling
get_attachment(...).
Apparently some xml tags in the GetAttachment operation had the
wrong namespace. (<m:IncludeMimeContent> instead of
<t:IncludeMimeContent>) Which wasn't that big of a problem, since
the tags were empty and supposed to define the default value.
But when I fixed the namespace, the exchange server complained about
the xml tags being invalid when they don't have a value.
As you can see in the get_attachment function, the
<t:IncludeMimeContent> tag works properly with either true or false
as the value.
AFAIK exchange only uses default values if the xml tag doesn't exist.
If it exists, it needs to have a value.
But if the xml tag has the wrong namespace, it's ignored entirely.

Nevertheless, I added the attachment::get_mime_content() function.
Not sure if that is the best way to do it. It's properly better to be able
to get the item of the item attachment as it's proper type. Meaning
either as message, calendar_item or contact. But I didn't know how.

So right now, it does just what I want. It allows me to get the mime
content as base64 and write it to a file.