### PR TITLE
Add support of Contact information in Resolve Names resolutions

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -16676,6 +16676,26 @@ public:
     // manager_mailbox
     // direct_reports
 
+    std::string get_user_smime_certificate() const
+    {
+	const auto node = xml().get_node("UserSMIMECertificate");
+	if (!node) {
+		return "";
+	}
+	auto base64binary = node->first_node("Base64Binary");
+	return base64binary ? std::string(base64binary->value(), base64binary->value_size()) : "";
+    }
+
+    std::string get_msexchange_certificate() const
+    {
+	const auto node = xml().get_node("MSExchangeCertificate");
+	if (!node) {
+		return "";
+	}
+	auto base64binary = node->first_node("Base64Binary");
+	return base64binary ? std::string(base64binary->value(), base64binary->value_size()) : "";
+    }
+
     //! Makes a contact instance from a \<Contact> XML element
     static contact from_xml_element(const rapidxml::xml_node<>& elem)
     {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -62,6 +62,8 @@
 namespace ews
 {
 
+class contact;
+
 #ifndef EWS_DOXYGEN_SHOULD_SKIP_THIS
 
 #    ifdef EWS_HAS_DEFAULT_TEMPLATE_ARGS_FOR_FUNCTIONS
@@ -9643,6 +9645,7 @@ struct resolution final
 {
     ews::mailbox mailbox;
     ews::directory_id directory_id;
+    std::shared_ptr<ews::contact> contact;
 };
 
 #if defined(EWS_HAS_NON_BUGGY_TYPE_TRAITS) &&                                  \
@@ -16683,6 +16686,15 @@ public:
                        internal::xml_subtree(elem));
     }
 
+    //! Makes a contact instance from a \<Contact> XML element that has no
+    //! ItemId. Is the case in resolution sets.
+    static contact from_xml_element_without_item_id(
+        const rapidxml::xml_node<>& elem)
+    {
+        item_id id;
+        return contact(std::move(id), internal::xml_subtree(elem));
+    }
+
 private:
     template <typename U> friend class basic_service;
 
@@ -23711,6 +23723,10 @@ namespace internal
                         directory_id id(directory_id_elem->value());
                         r.directory_id = id;
                     }
+
+                    r.contact = std::make_shared<ews::contact>(
+                        contact::from_xml_element_without_item_id(
+				*contact_elem));
                 }
 
                 resolutions.resolutions.emplace_back(r);

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -16682,7 +16682,7 @@ public:
 	if (!node) {
 		return "";
 	}
-	auto base64binary = node->first_node("Base64Binary");
+	auto base64binary = node->first_node_ns(internal::uri<>::microsoft::types(), "Base64Binary");
 	return base64binary ? std::string(base64binary->value(), base64binary->value_size()) : "";
     }
 
@@ -16692,7 +16692,7 @@ public:
 	if (!node) {
 		return "";
 	}
-	auto base64binary = node->first_node("Base64Binary");
+	auto base64binary = node->first_node_ns(internal::uri<>::microsoft::types(), "Base64Binary");
 	return base64binary ? std::string(base64binary->value(), base64binary->value_size()) : "";
     }
 
@@ -23735,8 +23735,8 @@ namespace internal
                             res->last_node()->local_name_size()))
                 {
                     auto contact_elem = res->last_node("t:Contact");
-                    auto directory_id_elem =
-                        contact_elem->first_node("t:Directory");
+                    auto directory_id_elem = contact_elem
+                        ->first_node_ns(internal::uri<>::microsoft::types(), "DirectoryId");
 
                     if (directory_id_elem)
                     {

--- a/tests/assets/resolve_names_response.xml
+++ b/tests/assets/resolve_names_response.xml
@@ -20,8 +20,11 @@
                 <t:ContactSource>ActiveDirectory</t:ContactSource>
 		<t:DirectoryId>&lt;GUID=abc-123-foo-bar&gt;</t:DirectoryId>
 		<t:UserSMIMECertificate>
-		  <t:Base64Binary>DEADBEEF</Base64Binary>
+		  <t:Base64Binary>U01JTUVDZXJ0aWZpY2F0ZQ==</Base64Binary>
 		</t:UserSMIMECertificate>
+		<t:MSExchangeCertificate>
+		  <t:Base64Binary>RXhjaGFuZ2VDZXJ0aWZpY2F0ZQ==</Base64Binary>
+		</t:MSExchangeCertificate>
               </t:Contact>
             </t:Resolution>
           </m:ResolutionSet>

--- a/tests/assets/resolve_names_response.xml
+++ b/tests/assets/resolve_names_response.xml
@@ -16,6 +16,7 @@
                 <t:MailboxType>Mailbox</t:MailboxType>
               </t:Mailbox>
               <t:Contact>
+                <t:DisplayName>User Number Two</t:DisplayName>
                 <t:ContactSource>ActiveDirectory</t:ContactSource>
                 <t:DirectoryId>&lt;GUID=abc-123-foo-bar&gt;</t:DirectoryId>
               </t:Contact>

--- a/tests/assets/resolve_names_response.xml
+++ b/tests/assets/resolve_names_response.xml
@@ -18,7 +18,10 @@
               <t:Contact>
                 <t:DisplayName>User Number Two</t:DisplayName>
                 <t:ContactSource>ActiveDirectory</t:ContactSource>
-                <t:DirectoryId>&lt;GUID=abc-123-foo-bar&gt;</t:DirectoryId>
+		<t:DirectoryId>&lt;GUID=abc-123-foo-bar&gt;</t:DirectoryId>
+		<t:UserSMIMECertificate>
+		  <t:Base64Binary>DEADBEEF</Base64Binary>
+		</t:UserSMIMECertificate>
               </t:Contact>
             </t:Resolution>
           </m:ResolutionSet>

--- a/tests/test_resolve_names.cpp
+++ b/tests/test_resolve_names.cpp
@@ -40,9 +40,11 @@ TEST_F(ResolveNamesTest, UserFound)
         service().resolve_names("name", ews::search_scope::active_directory);
     auto resolution_mailbox = response.resolutions[0].mailbox;
     auto resolution_id = response.resolutions[0].directory_id;
+    auto resolution_contact = response.resolutions[0].contact;
     EXPECT_EQ(resolution_mailbox.name(), "User2");
     EXPECT_EQ(resolution_mailbox.value(), "User2@example.com");
     EXPECT_EQ(resolution_id.get_id(), "<GUID=abc-123-foo-bar>");
+    EXPECT_EQ(resolution_contact.get_display_name(), "User Number Two");
 }
 
 TEST_F(ResolveNamesTest, SendCorrectRequest)

--- a/tests/test_resolve_names.cpp
+++ b/tests/test_resolve_names.cpp
@@ -44,7 +44,9 @@ TEST_F(ResolveNamesTest, UserFound)
     EXPECT_EQ(resolution_mailbox.name(), "User2");
     EXPECT_EQ(resolution_mailbox.value(), "User2@example.com");
     EXPECT_EQ(resolution_id.get_id(), "<GUID=abc-123-foo-bar>");
-    EXPECT_EQ(resolution_contact.get_display_name(), "User Number Two");
+    EXPECT_EQ(resolution_contact->get_display_name(), "User Number Two");
+    EXPECT_EQ(resolution_contact->get_user_smime_certificate(), "U01JTUVDZXJ0aWZpY2F0ZQ==");
+    EXPECT_EQ(resolution_contact->get_msexchange_certificate(), "RXhjaGFuZ2VDZXJ0aWZpY2F0ZQ==");
 }
 
 TEST_F(ResolveNamesTest, SendCorrectRequest)


### PR DESCRIPTION
First implementation for providing the Contact information in a Resolve Names resolution. The shared_ptr is used for the time being, but its use revised late.