### PR TITLE
 Compatible with "to_xml()" method and ItemId initialization method "item_id(std::string id)".

### DIFF
--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -9264,8 +9264,6 @@ public:
     //! Serializes this item_id to an XML string
     std::string to_xml() const
     {
-        // return "<t:ItemId Id=\"" + id() + "\" ChangeKey=\"" + change_key() +
-        //        "\"/>";
         std::stringstream sstr;
         sstr << "<t:ItemId Id=\"" << id_;
         if (!change_key_.empty()) {

--- a/include/ews/ews.hpp
+++ b/include/ews/ews.hpp
@@ -9264,8 +9264,15 @@ public:
     //! Serializes this item_id to an XML string
     std::string to_xml() const
     {
-        return "<t:ItemId Id=\"" + id() + "\" ChangeKey=\"" + change_key() +
-               "\"/>";
+        // return "<t:ItemId Id=\"" + id() + "\" ChangeKey=\"" + change_key() +
+        //        "\"/>";
+        std::stringstream sstr;
+        sstr << "<t:ItemId Id=\"" << id_;
+        if (!change_key_.empty()) {
+            sstr << "\" ChangeKey=\"" << change_key_;
+        }
+        sstr << "\"/>";
+        return sstr.str();
     }
 
     //! Makes an item_id instance from an <tt>\<ItemId></tt> XML element


### PR DESCRIPTION
If there is no ChangeKey when initializing item_id, to_xml() returns the data of <t:ItemId Id="AQMkADkzN..." ChangeKey=""/>，which will cause an error.